### PR TITLE
Refactor Switch DOM for accessibility and simplify variants; update tests and docs

### DIFF
--- a/docs/pages/form/switch/api.json
+++ b/docs/pages/form/switch/api.json
@@ -13,10 +13,6 @@
       "description": "Switch wrapper that coordinates input, track, thumb, and text content."
     },
     {
-      "name": "track",
-      "description": "Visible switch track that shows checked and unchecked state."
-    },
-    {
       "name": "thumb",
       "description": "Movable knob inside the switch track."
     },
@@ -123,7 +119,7 @@
       {
         "name": "onPointerDown",
         "required": false,
-        "type": "JSX.EventHandlerUnion<HTMLDivElement, PointerEvent, JSX.EventHandler<HTMLDivElement, PointerEvent>> | undefined",
+        "type": "JSX.EventHandlerUnion<HTMLButtonElement, PointerEvent, JSX.EventHandler<HTMLButtonElement, PointerEvent>> | undefined",
         "description": "Pointer down handler for the switch root container."
       },
       {
@@ -188,6 +184,12 @@
         "description": "Accessibility attribute forwarded by the rendered component."
       },
       {
+        "name": "aria-describedby",
+        "required": false,
+        "type": "boolean | string | undefined",
+        "description": "References descriptive text associated with the control."
+      },
+      {
         "name": "aria-disabled",
         "required": false,
         "type": "boolean | string | undefined",
@@ -204,6 +206,12 @@
         "required": false,
         "type": "boolean | string | undefined",
         "description": "Provides an accessible label when visible text is not sufficient."
+      },
+      {
+        "name": "aria-labelledby",
+        "required": false,
+        "type": "boolean | string | undefined",
+        "description": "References the element that labels the control or region."
       },
       {
         "name": "aria-readonly",
@@ -258,12 +266,6 @@
     ],
     "slots": [
       {
-        "name": "container",
-        "cssVariables": [],
-        "dataAttributes": [],
-        "ariaAttributes": []
-      },
-      {
         "name": "description",
         "cssVariables": [],
         "dataAttributes": [],
@@ -275,16 +277,54 @@
         "dataAttributes": [],
         "ariaAttributes": [
           {
+            "name": "aria-hidden",
+            "required": false,
+            "type": "boolean | string | undefined",
+            "description": "Hides decorative content from assistive technology."
+          }
+        ]
+      },
+      {
+        "name": "label",
+        "cssVariables": [],
+        "dataAttributes": [],
+        "ariaAttributes": []
+      },
+      {
+        "name": "root",
+        "cssVariables": [],
+        "dataAttributes": [
+          {
+            "name": "data-invalid",
+            "required": false,
+            "type": "string | undefined",
+            "description": "Present when the field has a validation error."
+          }
+        ],
+        "ariaAttributes": [
+          {
             "name": "aria-checked",
             "required": false,
             "type": "boolean | string | undefined",
             "description": "Accessibility attribute forwarded by the rendered component."
           },
           {
+            "name": "aria-describedby",
+            "required": false,
+            "type": "boolean | string | undefined",
+            "description": "References descriptive text associated with the control."
+          },
+          {
             "name": "aria-disabled",
             "required": false,
             "type": "boolean | string | undefined",
             "description": "Indicates that the control is disabled."
+          },
+          {
+            "name": "aria-labelledby",
+            "required": false,
+            "type": "boolean | string | undefined",
+            "description": "References the element that labels the control or region."
           },
           {
             "name": "aria-readonly",
@@ -307,41 +347,9 @@
         ]
       },
       {
-        "name": "label",
-        "cssVariables": [],
-        "dataAttributes": [],
-        "ariaAttributes": []
-      },
-      {
-        "name": "root",
-        "cssVariables": [],
-        "dataAttributes": [],
-        "ariaAttributes": [
-          {
-            "name": "role",
-            "required": false,
-            "type": "string",
-            "description": "Defines the semantic role exposed to assistive technology."
-          }
-        ]
-      },
-      {
         "name": "thumb",
         "cssVariables": [],
         "dataAttributes": [],
-        "ariaAttributes": []
-      },
-      {
-        "name": "track",
-        "cssVariables": [],
-        "dataAttributes": [
-          {
-            "name": "data-invalid",
-            "required": false,
-            "type": "string | undefined",
-            "description": "Present when the field has a validation error."
-          }
-        ],
         "ariaAttributes": []
       },
       {

--- a/docs/pages/form/switch/api.json
+++ b/docs/pages/form/switch/api.json
@@ -123,7 +123,7 @@
       {
         "name": "onPointerDown",
         "required": false,
-        "type": "JSX.EventHandlerUnion<HTMLButtonElement, PointerEvent, JSX.EventHandler<HTMLButtonElement, PointerEvent>> | undefined",
+        "type": "JSX.EventHandler<HTMLButtonElement, PointerEvent> | undefined",
         "description": "Pointer down handler for the switch root container."
       },
       {
@@ -244,6 +244,12 @@
         "description": "Present when the item is checked or selected."
       },
       {
+        "name": "data-disabled",
+        "required": false,
+        "type": "string | undefined",
+        "description": "Present when the component or item is disabled."
+      },
+      {
         "name": "data-invalid",
         "required": false,
         "type": "string | undefined",
@@ -254,6 +260,12 @@
         "required": false,
         "type": "string | undefined",
         "description": "Present when the component is loading."
+      },
+      {
+        "name": "data-readonly",
+        "required": false,
+        "type": "string | undefined",
+        "description": "Present when the field is read-only."
       },
       {
         "name": "data-slot",
@@ -303,7 +315,26 @@
       {
         "name": "thumb",
         "cssVariables": [],
-        "dataAttributes": [],
+        "dataAttributes": [
+          {
+            "name": "data-checked",
+            "required": false,
+            "type": "string | undefined",
+            "description": "Present when the item is checked or selected."
+          },
+          {
+            "name": "data-disabled",
+            "required": false,
+            "type": "string | undefined",
+            "description": "Present when the component or item is disabled."
+          },
+          {
+            "name": "data-readonly",
+            "required": false,
+            "type": "string | undefined",
+            "description": "Present when the field is read-only."
+          }
+        ],
         "ariaAttributes": []
       },
       {
@@ -311,10 +342,28 @@
         "cssVariables": [],
         "dataAttributes": [
           {
+            "name": "data-checked",
+            "required": false,
+            "type": "string | undefined",
+            "description": "Present when the item is checked or selected."
+          },
+          {
+            "name": "data-disabled",
+            "required": false,
+            "type": "string | undefined",
+            "description": "Present when the component or item is disabled."
+          },
+          {
             "name": "data-invalid",
             "required": false,
             "type": "string | undefined",
             "description": "Present when the field has a validation error."
+          },
+          {
+            "name": "data-readonly",
+            "required": false,
+            "type": "string | undefined",
+            "description": "Present when the field is read-only."
           }
         ],
         "ariaAttributes": [

--- a/docs/pages/form/switch/api.json
+++ b/docs/pages/form/switch/api.json
@@ -13,10 +13,6 @@
       "description": "Switch wrapper that coordinates input, track, thumb, and text content."
     },
     {
-      "name": "container",
-      "description": "Text column that groups label and description."
-    },
-    {
       "name": "track",
       "description": "Visible switch track that shows checked and unchecked state."
     },

--- a/docs/pages/form/switch/api.json
+++ b/docs/pages/form/switch/api.json
@@ -13,6 +13,10 @@
       "description": "Switch wrapper that coordinates input, track, thumb, and text content."
     },
     {
+      "name": "track",
+      "description": "Visible switch track that shows checked and unchecked state."
+    },
+    {
       "name": "thumb",
       "description": "Movable knob inside the switch track."
     },
@@ -293,6 +297,18 @@
       {
         "name": "root",
         "cssVariables": [],
+        "dataAttributes": [],
+        "ariaAttributes": []
+      },
+      {
+        "name": "thumb",
+        "cssVariables": [],
+        "dataAttributes": [],
+        "ariaAttributes": []
+      },
+      {
+        "name": "track",
+        "cssVariables": [],
         "dataAttributes": [
           {
             "name": "data-invalid",
@@ -345,12 +361,6 @@
             "description": "Defines the semantic role exposed to assistive technology."
           }
         ]
-      },
-      {
-        "name": "thumb",
-        "cssVariables": [],
-        "dataAttributes": [],
-        "ariaAttributes": []
       },
       {
         "name": "wrapper",

--- a/src/forms/switch/switch.class.ts
+++ b/src/forms/switch/switch.class.ts
@@ -1,19 +1,9 @@
 import type { VariantProps } from 'cls-variant'
 
-import { CHECKABLE_CONTAINER_SIZE_VARIANT } from '../../shared/cva-common.class'
 import { cva } from '../../shared/utils'
 
-export const switchContainerVariants = cva('flex items-center', {
-  defaultVariants: {
-    size: 'md',
-  },
-  variants: {
-    size: CHECKABLE_CONTAINER_SIZE_VARIANT,
-  },
-})
-
 export const switchTrackVariants = cva(
-  'p-px outline-none border border-transparent rounded-full bg-input inline-flex shrink-0 cursor-pointer transition-[color,box-shadow] items-center peer-focus-visible:effect-fv-border data-invalid:effect-invalid dark:bg-input/80 data-checked:bg-primary',
+  'p-px outline-none border border-transparent rounded-full bg-input inline-flex shrink-0 cursor-pointer transition-[color,box-shadow] items-center group-focus-visible:effect-fv-border peer-focus-visible:effect-fv-border data-invalid:effect-invalid dark:bg-input/80 data-checked:bg-primary',
   {
     defaultVariants: {
       size: 'md',
@@ -63,4 +53,4 @@ export const switchWrapperVariants = cva('', {
   },
 })
 
-export type SwitchVariantProps = VariantProps<typeof switchContainerVariants>
+export type SwitchVariantProps = VariantProps<typeof switchTrackVariants>

--- a/src/forms/switch/switch.class.ts
+++ b/src/forms/switch/switch.class.ts
@@ -2,8 +2,8 @@ import type { VariantProps } from 'cls-variant'
 
 import { cva } from '../../shared/utils'
 
-export const switchTrackVariants = cva(
-  'p-px outline-none border border-transparent rounded-full bg-input inline-flex shrink-0 cursor-pointer transition-[color,box-shadow] items-center group-focus-visible:effect-fv-border peer-focus-visible:effect-fv-border data-invalid:effect-invalid dark:bg-input/80 data-checked:bg-primary',
+export const switchRootVariants = cva(
+  'p-px outline-none border border-transparent rounded-full bg-input inline-flex shrink-0 cursor-pointer transition-[color,box-shadow] items-center focus-visible:effect-fv-border data-invalid:effect-invalid dark:bg-input/80 data-checked:bg-primary',
   {
     defaultVariants: {
       size: 'md',
@@ -53,4 +53,4 @@ export const switchWrapperVariants = cva('', {
   },
 })
 
-export type SwitchVariantProps = VariantProps<typeof switchTrackVariants>
+export type SwitchVariantProps = VariantProps<typeof switchRootVariants>

--- a/src/forms/switch/switch.class.ts
+++ b/src/forms/switch/switch.class.ts
@@ -2,7 +2,7 @@ import type { VariantProps } from 'cls-variant'
 
 import { cva } from '../../shared/utils'
 
-export const switchRootVariants = cva(
+export const switchTrackVariants = cva(
   'p-px outline-none border border-transparent rounded-full bg-input inline-flex shrink-0 cursor-pointer transition-[color,box-shadow] items-center focus-visible:effect-fv-border data-invalid:effect-invalid dark:bg-input/80 data-checked:bg-primary',
   {
     defaultVariants: {
@@ -53,4 +53,4 @@ export const switchWrapperVariants = cva('', {
   },
 })
 
-export type SwitchVariantProps = VariantProps<typeof switchRootVariants>
+export type SwitchVariantProps = VariantProps<typeof switchTrackVariants>

--- a/src/forms/switch/switch.test.tsx
+++ b/src/forms/switch/switch.test.tsx
@@ -6,59 +6,66 @@ import { FormField } from '../form-field'
 
 import { Switch } from './switch'
 
+function expectSwitchChecked(element: Element, checked: boolean): void {
+  expect(element.getAttribute('aria-checked')).toBe(String(checked))
+}
+
 describe('Switch', () => {
   test('renders label and description with accessible switch input', () => {
     const screen = render(() => <Switch label="Email alerts" description="Receive updates" />)
 
     const switchInput = screen.getByRole('switch', { name: 'Email alerts' })
-    const label = screen.getByText('Email alerts')
+    const root = screen.container.querySelector('[data-slot="root"]')
 
     expect(switchInput).not.toBeNull()
-    expect(label.getAttribute('for')).toBe(switchInput.getAttribute('id'))
+    const input = screen.container.querySelector('[data-slot="input"]')
+
+    expect(root?.tagName).toBe('BUTTON')
+    expect(input?.getAttribute('aria-hidden')).toBe('true')
     expect(screen.getByText('Receive updates')).not.toBeNull()
   })
 
   test('supports uncontrolled toggle', async () => {
     const screen = render(() => <Switch label="Marketing" />)
-    const switchInput = screen.getByRole('switch', { name: 'Marketing' }) as HTMLInputElement
+    const switchInput = screen.getByRole('switch', { name: 'Marketing' })
 
-    expect(switchInput.checked).toBe(false)
+    expectSwitchChecked(switchInput, false)
     await fireEvent.click(switchInput)
-    expect(switchInput.checked).toBe(true)
+    expectSwitchChecked(switchInput, true)
   })
 
   test('toggles with Space and Enter keys', async () => {
     const onChange = vi.fn()
     const screen = render(() => <Switch label="Keyboard" onChange={onChange} />)
-    const switchInput = screen.getByRole('switch', { name: 'Keyboard' }) as HTMLInputElement
+    const switchInput = screen.getByRole('switch', { name: 'Keyboard' })
 
     await fireEvent.keyDown(switchInput, { key: ' ' })
 
     expect(onChange).toHaveBeenCalledTimes(1)
     expect(onChange).toHaveBeenLastCalledWith(true)
-    expect(switchInput.checked).toBe(true)
+    expectSwitchChecked(switchInput, true)
 
     await fireEvent.keyDown(switchInput, { key: 'Enter' })
 
     expect(onChange).toHaveBeenCalledTimes(2)
     expect(onChange).toHaveBeenLastCalledWith(false)
-    expect(switchInput.checked).toBe(false)
+    expectSwitchChecked(switchInput, false)
   })
 
   test('does not toggle when disabled', async () => {
     const onChange = vi.fn()
     const screen = render(() => <Switch disabled label="Disabled" onChange={onChange} />)
-    const switchInput = screen.getByRole('switch', { name: 'Disabled' }) as HTMLInputElement
+    const switchInput = screen.getByRole('switch', { name: 'Disabled' })
     const track = screen.container.querySelector('[data-slot="track"]') as HTMLElement
 
-    expect(switchInput.disabled).toBe(true)
+    expect(switchInput.getAttribute('aria-disabled')).toBe('true')
 
     await fireEvent.click(switchInput)
     await fireEvent.click(track)
     await fireEvent.keyDown(switchInput, { key: ' ' })
     await fireEvent.keyDown(switchInput, { key: 'Enter' })
 
-    expect(switchInput.checked).toBe(false)
+    expectSwitchChecked(switchInput, false)
     expect(onChange).not.toHaveBeenCalled()
   })
 
@@ -68,17 +75,19 @@ describe('Switch', () => {
     ))
 
     const switchInput = screen.getByRole('switch', { name: 'Newsletter' })
+    const input = screen.container.querySelector('[data-slot="input"]')
 
     expect(switchInput.getAttribute('id')).toBe('newsletter-switch')
-    expect(switchInput.getAttribute('name')).toBe('newsletter')
-    expect(switchInput.getAttribute('value')).toBe('yes')
-    expect(switchInput.getAttribute('required')).not.toBeNull()
+    expect(input?.getAttribute('id')).toBe('newsletter-switch-input')
+    expect(input?.getAttribute('name')).toBe('newsletter')
+    expect(input?.getAttribute('value')).toBe('yes')
+    expect(input?.getAttribute('required')).not.toBeNull()
   })
 
   test('keeps controlled state while emitting onChange', async () => {
     const onChange = vi.fn()
     const screen = render(() => <Switch checked label="Controlled" onChange={onChange} />)
-    const switchInput = screen.getByRole('switch', { name: 'Controlled' }) as HTMLInputElement
+    const switchInput = screen.getByRole('switch', { name: 'Controlled' })
 
     await fireEvent.click(switchInput)
 
@@ -86,26 +95,26 @@ describe('Switch', () => {
     expect(onChange).toHaveBeenCalledWith(false)
 
     await waitFor(() => {
-      expect(switchInput.checked).toBe(true)
+      expectSwitchChecked(switchInput, true)
     })
   })
 
   test('does not toggle a controlled readOnly switch', async () => {
     const onChange = vi.fn()
     const screen = render(() => <Switch checked readOnly label="Readonly" onChange={onChange} />)
-    const switchInput = screen.getByRole('switch', { name: 'Readonly' }) as HTMLInputElement
+    const switchInput = screen.getByRole('switch', { name: 'Readonly' })
 
     expect(switchInput.getAttribute('aria-readonly')).toBe('true')
 
     await fireEvent.click(switchInput)
 
-    expect(switchInput.checked).toBe(true)
+    expectSwitchChecked(switchInput, true)
     expect(onChange).not.toHaveBeenCalled()
 
     await fireEvent.keyDown(switchInput, { key: ' ' })
     await fireEvent.keyDown(switchInput, { key: 'Enter' })
 
-    expect(switchInput.checked).toBe(true)
+    expectSwitchChecked(switchInput, true)
     expect(onChange).not.toHaveBeenCalled()
   })
 
@@ -116,17 +125,17 @@ describe('Switch', () => {
     ))
     const switchInput = screen.getByRole('switch', {
       name: 'Readonly uncontrolled',
-    }) as HTMLInputElement
+    })
 
     await fireEvent.click(switchInput)
 
-    expect(switchInput.checked).toBe(false)
+    expectSwitchChecked(switchInput, false)
     expect(onChange).not.toHaveBeenCalled()
 
     await fireEvent.keyDown(switchInput, { key: ' ' })
     await fireEvent.keyDown(switchInput, { key: 'Enter' })
 
-    expect(switchInput.checked).toBe(false)
+    expectSwitchChecked(switchInput, false)
     expect(onChange).not.toHaveBeenCalled()
   })
 
@@ -135,9 +144,9 @@ describe('Switch', () => {
     const screen = render(() => (
       <Switch checked={1} trueValue={1} falseValue={0} label="Visibility" onChange={onChange} />
     ))
-    const switchInput = screen.getByRole('switch', { name: 'Visibility' }) as HTMLInputElement
+    const switchInput = screen.getByRole('switch', { name: 'Visibility' })
 
-    expect(switchInput.checked).toBe(true)
+    expectSwitchChecked(switchInput, true)
 
     await fireEvent.click(switchInput)
 
@@ -145,7 +154,7 @@ describe('Switch', () => {
     expect(onChange).toHaveBeenCalledWith(0)
 
     await waitFor(() => {
-      expect(switchInput.checked).toBe(true)
+      expectSwitchChecked(switchInput, true)
     })
   })
 
@@ -160,23 +169,23 @@ describe('Switch', () => {
       </Form>
     ))
 
-    const switchInput = screen.getByRole('switch', { name: 'Visibility' }) as HTMLInputElement
+    const switchInput = screen.getByRole('switch', { name: 'Visibility' })
 
     expect(state.visibility).toBe(1)
-    expect(switchInput.checked).toBe(true)
+    expectSwitchChecked(switchInput, true)
 
     await fireEvent.click(switchInput)
 
     await waitFor(() => {
       expect(state.visibility).toBe(0)
-      expect(switchInput.checked).toBe(false)
+      expectSwitchChecked(switchInput, false)
     })
 
     await fireEvent.click(switchInput)
 
     await waitFor(() => {
       expect(state.visibility).toBe(1)
-      expect(switchInput.checked).toBe(true)
+      expectSwitchChecked(switchInput, true)
     })
   })
 
@@ -191,11 +200,11 @@ describe('Switch', () => {
       </Form>
     ))
 
-    const switchInput = screen.getByRole('switch', { name: 'Visibility' }) as HTMLInputElement
+    const switchInput = screen.getByRole('switch', { name: 'Visibility' })
 
     await waitFor(() => {
       expect(state.visibility).toBe(1)
-      expect(switchInput.checked).toBe(true)
+      expectSwitchChecked(switchInput, true)
     })
   })
 
@@ -210,11 +219,11 @@ describe('Switch', () => {
       </Form>
     ))
 
-    const switchInput = screen.getByRole('switch', { name: 'Visibility' }) as HTMLInputElement
+    const switchInput = screen.getByRole('switch', { name: 'Visibility' })
 
     await waitFor(() => {
       expect(state.visibility).toBe(0)
-      expect(switchInput.checked).toBe(false)
+      expectSwitchChecked(switchInput, false)
     })
   })
 
@@ -229,11 +238,11 @@ describe('Switch', () => {
       </Form>
     ))
 
-    const switchInput = screen.getByRole('switch', { name: 'Visibility' }) as HTMLInputElement
+    const switchInput = screen.getByRole('switch', { name: 'Visibility' })
 
     await waitFor(() => {
       expect(state.visibility).toBe(1)
-      expect(switchInput.checked).toBe(true)
+      expectSwitchChecked(switchInput, true)
     })
   })
 
@@ -243,7 +252,7 @@ describe('Switch', () => {
     ))
 
     const switchInput = screen.getByRole('switch', { name: 'Loading' })
-    expect((switchInput as HTMLInputElement).disabled).toBe(true)
+    expect(switchInput.getAttribute('aria-disabled')).toBe('true')
     expect(screen.getByTestId('loading-icon').textContent).toBe('L')
   })
 
@@ -255,7 +264,7 @@ describe('Switch', () => {
         uncheckedIcon={<span data-testid="unchecked-icon">U</span>}
       />
     ))
-    const switchInput = screen.getByRole('switch', { name: 'Icon state' }) as HTMLInputElement
+    const switchInput = screen.getByRole('switch', { name: 'Icon state' })
 
     expect(screen.getByTestId('unchecked-icon').textContent).toBe('U')
     await fireEvent.click(switchInput)
@@ -312,20 +321,20 @@ describe('Switch', () => {
     ))
 
     const form = screen.container.querySelector('form') as HTMLFormElement
-    const switchInput = screen.getByRole('switch', { name: 'Enabled' }) as HTMLInputElement
+    const switchInput = screen.getByRole('switch', { name: 'Enabled' })
 
-    expect(switchInput.checked).toBe(true)
+    expectSwitchChecked(switchInput, true)
     expect(new FormData(form).get('enabled')).toBe('yes')
 
     await fireEvent.click(switchInput)
 
-    expect(switchInput.checked).toBe(false)
+    expectSwitchChecked(switchInput, false)
     expect(new FormData(form).has('enabled')).toBe(false)
 
     form.reset()
 
     await waitFor(() => {
-      expect(switchInput.checked).toBe(true)
+      expectSwitchChecked(switchInput, true)
       expect(new FormData(form).get('enabled')).toBe('yes')
     })
   })

--- a/src/forms/switch/switch.test.tsx
+++ b/src/forms/switch/switch.test.tsx
@@ -56,12 +56,9 @@ describe('Switch', () => {
     const onChange = vi.fn()
     const screen = render(() => <Switch disabled label="Disabled" onChange={onChange} />)
     const switchInput = screen.getByRole('switch', { name: 'Disabled' })
-    const track = screen.container.querySelector('[data-slot="track"]') as HTMLElement
-
     expect(switchInput.getAttribute('aria-disabled')).toBe('true')
 
     await fireEvent.click(switchInput)
-    await fireEvent.click(track)
     await fireEvent.keyDown(switchInput, { key: ' ' })
     await fireEvent.keyDown(switchInput, { key: 'Enter' })
 
@@ -344,13 +341,12 @@ describe('Switch', () => {
 
     const root = screen.container.querySelector('[data-slot="root"]')
     const input = screen.container.querySelector('[data-slot="input"]')
-    const base = screen.container.querySelector('[data-slot="track"]')
     const wrapper = screen.container.querySelector('[data-slot="wrapper"]')
 
-    expect(root?.className).not.toContain('cursor-pointer')
+    expect(root?.className).toContain('cursor-pointer')
     expect(input?.className).toContain('peer')
-    expect(base?.className).toContain('peer-focus-visible:effect-fv-border')
-    expect(base?.className).toContain('w-11')
+    expect(root?.className).toContain('focus-visible:effect-fv-border')
+    expect(root?.className).toContain('w-11')
     expect(wrapper?.className).toContain('ms-3')
     expect(wrapper?.className).toContain('text-base')
   })

--- a/src/forms/switch/switch.test.tsx
+++ b/src/forms/switch/switch.test.tsx
@@ -16,11 +16,13 @@ describe('Switch', () => {
 
     const switchInput = screen.getByRole('switch', { name: 'Email alerts' })
     const root = screen.container.querySelector('[data-slot="root"]')
+    const track = screen.container.querySelector('[data-slot="track"]')
 
     expect(switchInput).not.toBeNull()
     const input = screen.container.querySelector('[data-slot="input"]')
 
-    expect(root?.tagName).toBe('BUTTON')
+    expect(root?.tagName).toBe('DIV')
+    expect(track?.tagName).toBe('BUTTON')
     expect(input?.getAttribute('aria-hidden')).toBe('true')
     expect(screen.getByText('Receive updates')).not.toBeNull()
   })
@@ -341,12 +343,14 @@ describe('Switch', () => {
 
     const root = screen.container.querySelector('[data-slot="root"]')
     const input = screen.container.querySelector('[data-slot="input"]')
+    const track = screen.container.querySelector('[data-slot="track"]')
     const wrapper = screen.container.querySelector('[data-slot="wrapper"]')
 
-    expect(root?.className).toContain('cursor-pointer')
+    expect(root?.className).toContain('flex flex-row')
+    expect(track?.className).toContain('cursor-pointer')
     expect(input?.className).toContain('peer')
-    expect(root?.className).toContain('focus-visible:effect-fv-border')
-    expect(root?.className).toContain('w-11')
+    expect(track?.className).toContain('focus-visible:effect-fv-border')
+    expect(track?.className).toContain('w-11')
     expect(wrapper?.className).toContain('ms-3')
     expect(wrapper?.className).toContain('text-base')
   })

--- a/src/forms/switch/switch.tsx
+++ b/src/forms/switch/switch.tsx
@@ -17,20 +17,12 @@ import type {
 } from '../form-field/form-options'
 
 import type { SwitchVariantProps } from './switch.class'
-import {
-  switchTrackVariants,
-  switchContainerVariants,
-  switchThumbVariants,
-  switchWrapperVariants,
-} from './switch.class'
+import { switchTrackVariants, switchThumbVariants, switchWrapperVariants } from './switch.class'
 
 export namespace SwitchT {
   export interface Slot<T = unknown> {
     /** Switch wrapper that coordinates input, track, thumb, and text content. */
     root?: T
-
-    /** Text column that groups label and description. */
-    container?: T
 
     /** Visible switch track that shows checked and unchecked state. */
     track?: T
@@ -66,7 +58,7 @@ export namespace SwitchT {
     /**
      * Pointer down handler for the switch root container.
      */
-    onPointerDown?: JSX.EventHandlerUnion<HTMLDivElement, PointerEvent>
+    onPointerDown?: JSX.EventHandlerUnion<HTMLButtonElement, PointerEvent>
 
     /**
      * Native value submitted when the switch is checked.
@@ -187,6 +179,8 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
         ) ?? merged.falseValue,
     }),
   )
+  const labelId = createMemo(() => `${field.id()}-label`)
+  const descriptionId = createMemo(() => `${field.id()}-description`)
 
   let inputEl: HTMLInputElement | undefined
 
@@ -271,7 +265,6 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
     }
 
     onChange(!checked())
-    inputEl?.focus()
   }
 
   onMount(() => {
@@ -297,7 +290,7 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
     useEventListener(form, 'reset', onReset)
   })
 
-  function onInputKeyDown(event: KeyboardEvent): void {
+  function onRootKeyDown(event: KeyboardEvent): void {
     if (event.key !== ' ' && event.key !== 'Enter') {
       return
     }
@@ -323,65 +316,63 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
   }
 
   return (
-    <div
-      id={`${field.id()}-root`}
-      role="group"
-      data-slot="root"
-      style={merged.styles?.root}
-      class={cn(
-        'flex items-start relative',
-        field.disabled() && 'effect-dis',
-        merged.classes?.root,
-      )}
-      onPointerDown={onRootPointerDown}
-      {...dataAttrs()}
-    >
-      <div
-        data-slot="container"
-        style={merged.styles?.container}
-        class={switchContainerVariants(
-          {
-            size: field.size(),
-          },
-          merged.classes?.container,
-        )}
-      >
-        <HiddenInput
-          ref={(element) => {
-            inputEl = element
-          }}
-          id={field.id()}
-          type="checkbox"
-          role="switch"
-          name={field.name()}
-          value={merged.value}
-          checked={Boolean(checked())}
-          required={merged.required}
-          disabled={field.disabled()}
-          readOnly={readOnly()}
-          aria-checked={Boolean(checked())}
-          aria-required={merged.required || undefined}
-          aria-disabled={field.disabled() || undefined}
-          aria-readonly={readOnly() || undefined}
-          class="peer"
-          data-slot="input"
-          onChange={(event) => {
-            event.stopPropagation()
+    <>
+      <HiddenInput
+        ref={(element) => {
+          inputEl = element
+        }}
+        id={`${field.id()}-input`}
+        type="checkbox"
+        name={field.name()}
+        value={merged.value}
+        checked={Boolean(checked())}
+        required={merged.required}
+        disabled={field.disabled()}
+        readOnly={readOnly()}
+        tabIndex={-1}
+        aria-hidden="true"
+        class="peer"
+        data-slot="input"
+        onChange={(event) => {
+          event.stopPropagation()
 
-            if (field.disabled() || readOnly()) {
-              event.currentTarget.checked = Boolean(checked())
-              return
-            }
-
-            onChange(event.currentTarget.checked)
+          if (field.disabled() || readOnly()) {
             event.currentTarget.checked = Boolean(checked())
-          }}
-          onKeyDown={onInputKeyDown}
-          {...dataAttrs()}
-          {...field.ariaAttrs()}
-        />
+            return
+          }
 
-        <div
+          onChange(event.currentTarget.checked)
+          event.currentTarget.checked = Boolean(checked())
+        }}
+        {...dataAttrs()}
+      />
+
+      <button
+        id={field.id()}
+        type="button"
+        role="switch"
+        disabled={field.disabled()}
+        data-slot="root"
+        aria-checked={Boolean(checked())}
+        aria-required={merged.required || undefined}
+        aria-disabled={field.disabled() || undefined}
+        aria-readonly={readOnly() || undefined}
+        aria-labelledby={merged.label ? labelId() : undefined}
+        aria-describedby={merged.description ? descriptionId() : undefined}
+        {...field.ariaAttrs()}
+        style={merged.styles?.root}
+        class={cn(
+          'group text-start flex items-start relative',
+          field.disabled() && 'effect-dis',
+          merged.classes?.root,
+        )}
+        onPointerDown={onRootPointerDown}
+        onClick={() => toggle()}
+        onKeyDown={onRootKeyDown}
+        {...dataAttrs()}
+      >
+        <span
+          aria-hidden="true"
           data-slot="track"
           style={merged.styles?.track}
           data-invalid={field.invalid() ? '' : undefined}
@@ -391,10 +382,9 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
             },
             merged.classes?.track,
           )}
-          onClick={() => toggle()}
           {...dataAttrs()}
         >
-          <div
+          <span
             data-slot="thumb"
             style={merged.styles?.thumb}
             class={switchThumbVariants(
@@ -419,47 +409,48 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
                 />
               )}
             </Show>
-          </div>
-        </div>
-      </div>
+          </span>
+        </span>
 
-      <Show when={merged.label || merged.description}>
-        <div
-          data-slot="wrapper"
-          style={merged.styles?.wrapper}
-          class={switchWrapperVariants(
-            {
-              size: field.size(),
-            },
-            merged.classes?.wrapper,
-          )}
-        >
-          <Show when={merged.label}>
-            <label
-              for={field.id()}
-              data-slot="label"
-              style={merged.styles?.label}
-              class={cn(
-                'text-foreground font-medium block cursor-pointer',
-                merged.required && "after:(text-destructive ms-0.5 content-['*'])",
-                merged.classes?.label,
-              )}
-            >
-              {merged.label}
-            </label>
-          </Show>
+        <Show when={merged.label || merged.description}>
+          <span
+            data-slot="wrapper"
+            style={merged.styles?.wrapper}
+            class={switchWrapperVariants(
+              {
+                size: field.size(),
+              },
+              merged.classes?.wrapper,
+            )}
+          >
+            <Show when={merged.label}>
+              <span
+                id={labelId()}
+                data-slot="label"
+                style={merged.styles?.label}
+                class={cn(
+                  'text-foreground font-medium block cursor-pointer',
+                  merged.required && "after:(text-destructive ms-0.5 content-['*'])",
+                  merged.classes?.label,
+                )}
+              >
+                {merged.label}
+              </span>
+            </Show>
 
-          <Show when={merged.description}>
-            <p
-              data-slot="description"
-              style={merged.styles?.description}
-              class={cn('text-muted-foreground', merged.classes?.description)}
-            >
-              {merged.description}
-            </p>
-          </Show>
-        </div>
-      </Show>
-    </div>
+            <Show when={merged.description}>
+              <span
+                id={descriptionId()}
+                data-slot="description"
+                style={merged.styles?.description}
+                class={cn('text-muted-foreground block', merged.classes?.description)}
+              >
+                {merged.description}
+              </span>
+            </Show>
+          </span>
+        </Show>
+      </button>
+    </>
   )
 }

--- a/src/forms/switch/switch.tsx
+++ b/src/forms/switch/switch.tsx
@@ -17,15 +17,12 @@ import type {
 } from '../form-field/form-options'
 
 import type { SwitchVariantProps } from './switch.class'
-import { switchTrackVariants, switchThumbVariants, switchWrapperVariants } from './switch.class'
+import { switchRootVariants, switchThumbVariants, switchWrapperVariants } from './switch.class'
 
 export namespace SwitchT {
   export interface Slot<T = unknown> {
     /** Switch wrapper that coordinates input, track, thumb, and text content. */
     root?: T
-
-    /** Visible switch track that shows checked and unchecked state. */
-    track?: T
 
     /** Movable knob inside the switch track. */
     thumb?: T
@@ -353,6 +350,7 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
         role="switch"
         disabled={field.disabled()}
         data-slot="root"
+        data-invalid={field.invalid() ? '' : undefined}
         aria-checked={Boolean(checked())}
         aria-required={merged.required || undefined}
         aria-disabled={field.disabled() || undefined}
@@ -362,9 +360,13 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
         {...field.ariaAttrs()}
         style={merged.styles?.root}
         class={cn(
-          'group text-start flex items-start relative',
+          switchRootVariants(
+            {
+              size: field.size(),
+            },
+            merged.classes?.root,
+          ),
           field.disabled() && 'effect-dis',
-          merged.classes?.root,
         )}
         onPointerDown={onRootPointerDown}
         onClick={() => toggle()}
@@ -372,85 +374,72 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
         {...dataAttrs()}
       >
         <span
-          aria-hidden="true"
-          data-slot="track"
-          style={merged.styles?.track}
-          data-invalid={field.invalid() ? '' : undefined}
-          class={switchTrackVariants(
+          data-slot="thumb"
+          style={merged.styles?.thumb}
+          class={switchThumbVariants(
             {
               size: field.size(),
             },
-            merged.classes?.track,
+            merged.classes?.thumb,
           )}
           {...dataAttrs()}
         >
-          <span
-            data-slot="thumb"
-            style={merged.styles?.thumb}
-            class={switchThumbVariants(
-              {
-                size: field.size(),
-              },
-              merged.classes?.thumb,
-            )}
-            {...dataAttrs()}
-          >
-            <Show when={resolvedIconName()} keyed>
-              {(iconName) => (
-                <Icon
-                  name={iconName}
-                  data-checked={!merged.loading && checked() ? '' : undefined}
-                  data-unchecked={!merged.loading && !checked() ? '' : undefined}
-                  data-loading={merged.loading ? '' : undefined}
-                  class={cn(
-                    'text-primary size-10/12 transition-opacity absolute data-unchecked:(text-muted-foreground opacity-90) data-checked:opacity-100 data-loading:effect-loading',
-                    merged.classes?.icon,
-                  )}
-                />
-              )}
-            </Show>
-          </span>
-        </span>
-
-        <Show when={merged.label || merged.description}>
-          <span
-            data-slot="wrapper"
-            style={merged.styles?.wrapper}
-            class={switchWrapperVariants(
-              {
-                size: field.size(),
-              },
-              merged.classes?.wrapper,
-            )}
-          >
-            <Show when={merged.label}>
-              <span
-                id={labelId()}
-                data-slot="label"
-                style={merged.styles?.label}
+          <Show when={resolvedIconName()} keyed>
+            {(iconName) => (
+              <Icon
+                name={iconName}
+                data-checked={!merged.loading && checked() ? '' : undefined}
+                data-unchecked={!merged.loading && !checked() ? '' : undefined}
+                data-loading={merged.loading ? '' : undefined}
                 class={cn(
-                  'text-foreground font-medium block cursor-pointer',
-                  merged.required && "after:(text-destructive ms-0.5 content-['*'])",
-                  merged.classes?.label,
+                  'text-primary size-10/12 transition-opacity absolute data-unchecked:(text-muted-foreground opacity-90) data-checked:opacity-100 data-loading:effect-loading',
+                  merged.classes?.icon,
                 )}
-              >
-                {merged.label}
-              </span>
-            </Show>
-
-            <Show when={merged.description}>
-              <span
-                id={descriptionId()}
-                data-slot="description"
-                style={merged.styles?.description}
-                class={cn('text-muted-foreground block', merged.classes?.description)}
-              >
-                {merged.description}
-              </span>
-            </Show>
-          </span>
-        </Show>
+              />
+            )}
+          </Show>
+        </span>
       </button>
+
+      <Show when={merged.label || merged.description}>
+        <span
+          data-slot="wrapper"
+          style={merged.styles?.wrapper}
+          class={switchWrapperVariants(
+            {
+              size: field.size(),
+            },
+            merged.classes?.wrapper,
+          )}
+        >
+          <Show when={merged.label}>
+            <label
+              for={field.id()}
+              id={labelId()}
+              data-slot="label"
+              style={merged.styles?.label}
+              class={cn(
+                'text-foreground font-medium block cursor-pointer',
+                merged.required && "after:(text-destructive ms-0.5 content-['*'])",
+                merged.classes?.label,
+              )}
+            >
+              {merged.label}
+            </label>
+          </Show>
+
+          <Show when={merged.description}>
+            <span
+              id={descriptionId()}
+              data-slot="description"
+              style={merged.styles?.description}
+              class={cn('text-muted-foreground block', merged.classes?.description)}
+            >
+              {merged.description}
+            </span>
+          </Show>
+        </span>
+      </Show>
     </>
   )
 }

--- a/src/forms/switch/switch.tsx
+++ b/src/forms/switch/switch.tsx
@@ -17,12 +17,15 @@ import type {
 } from '../form-field/form-options'
 
 import type { SwitchVariantProps } from './switch.class'
-import { switchRootVariants, switchThumbVariants, switchWrapperVariants } from './switch.class'
+import { switchTrackVariants, switchThumbVariants, switchWrapperVariants } from './switch.class'
 
 export namespace SwitchT {
   export interface Slot<T = unknown> {
     /** Switch wrapper that coordinates input, track, thumb, and text content. */
     root?: T
+
+    /** Visible switch track that shows checked and unchecked state. */
+    track?: T
 
     /** Movable knob inside the switch track. */
     thumb?: T
@@ -313,7 +316,12 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
   }
 
   return (
-    <>
+    <div
+      data-slot="root"
+      style={merged.styles?.root}
+      class={cn('flex flex-row', merged.classes?.root)}
+      {...dataAttrs()}
+    >
       <HiddenInput
         ref={(element) => {
           inputEl = element
@@ -349,7 +357,7 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
         type="button"
         role="switch"
         disabled={field.disabled()}
-        data-slot="root"
+        data-slot="track"
         data-invalid={field.invalid() ? '' : undefined}
         aria-checked={Boolean(checked())}
         aria-required={merged.required || undefined}
@@ -358,13 +366,13 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
         aria-labelledby={merged.label ? labelId() : undefined}
         aria-describedby={merged.description ? descriptionId() : undefined}
         {...field.ariaAttrs()}
-        style={merged.styles?.root}
+        style={merged.styles?.track}
         class={cn(
-          switchRootVariants(
+          switchTrackVariants(
             {
               size: field.size(),
             },
-            merged.classes?.root,
+            merged.classes?.track,
           ),
           field.disabled() && 'effect-dis',
         )}
@@ -440,6 +448,6 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
           </Show>
         </span>
       </Show>
-    </>
+    </div>
   )
 }

--- a/src/forms/switch/switch.tsx
+++ b/src/forms/switch/switch.tsx
@@ -7,7 +7,7 @@ import { HiddenInput } from '../../shared/hidden-input'
 import type { BaseProps, SlotClassValue, SlotStyleValue } from '../../shared/types'
 import { useControllableValue } from '../../shared/use-controllable-value'
 import { useEventListener } from '../../shared/use-event-listener'
-import { callHandler, cn, useId } from '../../shared/utils'
+import { cn, useId } from '../../shared/utils'
 import { useFormField } from '../form-field/form-field-context'
 import type {
   FormDisableOption,
@@ -58,7 +58,7 @@ export namespace SwitchT {
     /**
      * Pointer down handler for the switch root container.
      */
-    onPointerDown?: JSX.EventHandlerUnion<HTMLButtonElement, PointerEvent>
+    onPointerDown?: JSX.EventHandler<HTMLButtonElement, PointerEvent>
 
     /**
      * Native value submitted when the switch is checked.
@@ -247,11 +247,6 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
   }
 
   const readOnly = createMemo(() => Boolean(merged.readOnly))
-  const dataAttrs = createMemo(() => ({
-    'data-checked': checked() ? '' : undefined,
-    'data-disabled': field.disabled() ? '' : undefined,
-    'data-readonly': readOnly() ? '' : undefined,
-  }))
 
   createEffect(() => {
     if (inputEl) {
@@ -299,8 +294,10 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
     toggle()
   }
 
-  function onRootPointerDown(event: PointerEvent): void {
-    callHandler(event, merged.onPointerDown)
+  function onPointerDown(
+    event: Parameters<JSX.EventHandler<HTMLButtonElement, PointerEvent>>[0],
+  ): void {
+    merged.onPointerDown?.(event)
 
     if (document.activeElement === inputEl) {
       event.preventDefault()
@@ -320,7 +317,6 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
       data-slot="root"
       style={merged.styles?.root}
       class={cn('flex flex-row', merged.classes?.root)}
-      {...dataAttrs()}
     >
       <HiddenInput
         ref={(element) => {
@@ -349,7 +345,6 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
           onChange(event.currentTarget.checked)
           event.currentTarget.checked = Boolean(checked())
         }}
-        {...dataAttrs()}
       />
 
       <button
@@ -367,22 +362,25 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
         aria-describedby={merged.description ? descriptionId() : undefined}
         {...field.ariaAttrs()}
         style={merged.styles?.track}
-        class={cn(
-          switchTrackVariants(
-            {
-              size: field.size(),
-            },
-            merged.classes?.track,
-          ),
+        class={switchTrackVariants(
+          {
+            size: field.size(),
+          },
+          merged.classes?.track,
           field.disabled() && 'effect-dis',
         )}
-        onPointerDown={onRootPointerDown}
+        onPointerDown={onPointerDown}
         onClick={() => toggle()}
         onKeyDown={onRootKeyDown}
-        {...dataAttrs()}
+        data-checked={checked() ? '' : undefined}
+        data-disabled={field.disabled() ? '' : undefined}
+        data-readonly={readOnly() ? '' : undefined}
       >
         <span
           data-slot="thumb"
+          data-checked={checked() ? '' : undefined}
+          data-disabled={field.disabled() ? '' : undefined}
+          data-readonly={readOnly() ? '' : undefined}
           style={merged.styles?.thumb}
           class={switchThumbVariants(
             {
@@ -390,7 +388,6 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
             },
             merged.classes?.thumb,
           )}
-          {...dataAttrs()}
         >
           <Show when={resolvedIconName()} keyed>
             {(iconName) => (

--- a/todo.md
+++ b/todo.md
@@ -5,7 +5,7 @@
   - [x] introduce a new variant `bold`, which will make the track thicker than thumb.
   - [x] use dot style in default variant, and use line style in bold variant.
   - [x] change default direction of vertial orientation to bottom -> top
-- [ ] refactor switch component's dom structure, make it more semantic and accessible, and remove unnecessary wrapper elements, dont show focus ring when clicked.
+- [x] refactor switch component's dom structure, make it more semantic and accessible, and remove unnecessary wrapper elements, dont show focus ring when clicked.
 - [ ] unify slot names, only contains inner element slots, the outest slot should be component itself, and add class / style props to component props, so no longer needed to setup classes / styles object for simple root component
 - [ ] find a way to add jsdoc for Variant 's props
 - [ ] unify custom render function prop with prefix `render`, target should be `renderXXXX`


### PR DESCRIPTION
### Motivation

- Make the Switch component more semantic and accessible by separating the native input from the visible control and reducing wrapper elements.
- Simplify variant typing and remove an unnecessary container variant to centralize track sizing and classes.
- Align tests and documentation with the new DOM structure and slot model.

### Description

- Reworked `Switch` markup to render a hidden checkbox (`HiddenInput`) and a visible `button` with `role="switch"`, explicit `aria-*` relations, and `aria-labelledby` / `aria-describedby` ids for label/description linking.
- Removed the `container` slot and related `switchContainerVariants`, adjusted `switch.class.ts` so `SwitchVariantProps` now references `switchTrackVariants`, and added `group-focus-visible:effect-fv-border` to the track classes.
- Updated event handling and keyboard support by moving keydown and pointer handling to the root button (`onRootKeyDown`, `onRootPointerDown`), prevented input focus steals on pointer down, and simplified toggle logic.
- Updated tests (`switch.test.tsx`) to match the new DOM: added `expectSwitchChecked` helper, assert against `aria-*` attributes and slot-marked elements (`data-slot=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4489a7353483309e6047e43185e965)