### PR TITLE
feat: support root class and style props

### DIFF
--- a/docs/components/docs-command-palette.tsx
+++ b/docs/components/docs-command-palette.tsx
@@ -75,13 +75,7 @@ export function DocsSearchTrigger(props: {
       <span class="i-lucide-search shrink-0 size-4 block" aria-hidden="true" />
       <Show when={variant() === 'desktop'}>
         <span class="text-left flex-1 truncate">Search...</span>
-        <Kbd
-          size="xs"
-          variant="outline"
-          value={['⌘', 'K']}
-          class="gap-1"
-          classes={{ item: 'text-[0.65rem]' }}
-        />
+        <Kbd size="xs" variant="outline" value={['⌘', 'K']} classes={{ item: 'text-[0.65rem]' }} />
       </Show>
     </button>
   )

--- a/docs/components/docs-command-palette.tsx
+++ b/docs/components/docs-command-palette.tsx
@@ -79,7 +79,8 @@ export function DocsSearchTrigger(props: {
           size="xs"
           variant="outline"
           value={['⌘', 'K']}
-          classes={{ root: 'gap-1', item: 'text-[0.65rem]' }}
+          class="gap-1"
+          classes={{ item: 'text-[0.65rem]' }}
         />
       </Show>
     </button>

--- a/docs/components/intro-components.tsx
+++ b/docs/components/intro-components.tsx
@@ -22,7 +22,7 @@ export const IntroComponents = () => {
 
   return (
     <section class="flex flex-col gap-4 relative">
-      <Badge variant="outline" class={'end-0 absolute -top-13'}>
+      <Badge variant="outline" class="end-0 absolute -top-13">
         {apiIndex.components.length} components
       </Badge>
 

--- a/docs/components/intro-components.tsx
+++ b/docs/components/intro-components.tsx
@@ -22,7 +22,7 @@ export const IntroComponents = () => {
 
   return (
     <section class="flex flex-col gap-4 relative">
-      <Badge variant="outline" classes={{ root: 'absolute end-0 -top-13' }}>
+      <Badge variant="outline" class={'end-0 absolute -top-13'}>
         {apiIndex.components.length} components
       </Badge>
 

--- a/docs/components/markdown.tsx
+++ b/docs/components/markdown.tsx
@@ -126,11 +126,7 @@ export function Markdown(input: RenderExampleMarkdownPageInput) {
                     <div class="text-2xl font-bold capitalize sm:text-3xl">{title()}</div>
                     <Show when={status()}>
                       {(nextStatus) => (
-                        <Badge
-                          size="sm"
-                          variant="outline"
-                          classes={{ root: 'tracking-wide font-semibold' }}
-                        >
+                        <Badge size="sm" variant="outline" class={'tracking-wide font-semibold'}>
                           {DOCS_HEADER_STATUS_LABELS[nextStatus()]}
                         </Badge>
                       )}

--- a/docs/components/markdown.tsx
+++ b/docs/components/markdown.tsx
@@ -126,7 +126,7 @@ export function Markdown(input: RenderExampleMarkdownPageInput) {
                     <div class="text-2xl font-bold capitalize sm:text-3xl">{title()}</div>
                     <Show when={status()}>
                       {(nextStatus) => (
-                        <Badge size="sm" variant="outline" class={'tracking-wide font-semibold'}>
+                        <Badge size="sm" variant="outline" class="tracking-wide font-semibold">
                           {DOCS_HEADER_STATUS_LABELS[nextStatus()]}
                         </Badge>
                       )}

--- a/docs/components/shiki-code-block.tsx
+++ b/docs/components/shiki-code-block.tsx
@@ -153,7 +153,7 @@ export const ShikiCodeBlock = (props: ShikiCodeBlockProps) => {
                   variant="outline"
                   aria-label="Expand code"
                   onClick={() => setIsExpanded(true)}
-                  classes={{ root: 'absolute bottom-2 left-1/2 translate--1/2' }}
+                  class={'translate--1/2 bottom-2 left-1/2 absolute'}
                 >
                   Expand code
                 </Button>

--- a/docs/components/shiki-code-block.tsx
+++ b/docs/components/shiki-code-block.tsx
@@ -153,7 +153,7 @@ export const ShikiCodeBlock = (props: ShikiCodeBlockProps) => {
                   variant="outline"
                   aria-label="Expand code"
                   onClick={() => setIsExpanded(true)}
-                  class={'translate--1/2 bottom-2 left-1/2 absolute'}
+                  class="translate--1/2 bottom-2 left-1/2 absolute"
                 >
                   Expand code
                 </Button>

--- a/docs/components/sidebar.tsx
+++ b/docs/components/sidebar.tsx
@@ -121,7 +121,7 @@ export const SidebarHeader = (props: SidebarHeaderProps) => {
         <img src="/favicon.svg" alt="icon" class="size-7" />
         <p class="text-lg font-semibold truncate">
           Moraine
-          <Badge size="xs" variant="outline" classes={{ root: 'font-mono ms-1.5' }}>
+          <Badge size="xs" variant="outline" class={'font-mono ms-1.5'}>
             v{version}
           </Badge>
         </p>

--- a/docs/components/sidebar.tsx
+++ b/docs/components/sidebar.tsx
@@ -121,7 +121,7 @@ export const SidebarHeader = (props: SidebarHeaderProps) => {
         <img src="/favicon.svg" alt="icon" class="size-7" />
         <p class="text-lg font-semibold truncate">
           Moraine
-          <Badge size="xs" variant="outline" class={'font-mono ms-1.5'}>
+          <Badge size="xs" variant="outline" class="font-mono ms-1.5">
             v{version}
           </Badge>
         </p>

--- a/docs/pages/form/checkbox-group/api.json
+++ b/docs/pages/form/checkbox-group/api.json
@@ -65,7 +65,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/form/checkbox-group/api.json
+++ b/docs/pages/form/checkbox-group/api.json
@@ -62,6 +62,12 @@
         "description": "Default checked icon for all items."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "CheckboxGroupT.Classes | undefined"
@@ -144,6 +150,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/form/checkbox/api.json
+++ b/docs/pages/form/checkbox/api.json
@@ -57,6 +57,12 @@
         "defaultValue": "icon-check"
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "CheckboxT.Classes | undefined"
@@ -162,6 +168,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/form/checkbox/api.json
+++ b/docs/pages/form/checkbox/api.json
@@ -60,7 +60,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/form/file-upload/api.json
+++ b/docs/pages/form/file-upload/api.json
@@ -78,6 +78,12 @@
         "defaultValue": "div"
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "FileUploadT.Classes | undefined"
@@ -226,6 +232,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/form/file-upload/api.json
+++ b/docs/pages/form/file-upload/api.json
@@ -81,7 +81,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/form/form-field/api.json
+++ b/docs/pages/form/form-field/api.json
@@ -61,6 +61,12 @@
         "description": "Children of the field, can be a render function."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "FormFieldT.Classes | undefined"
@@ -130,6 +136,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/form/form-field/api.json
+++ b/docs/pages/form/form-field/api.json
@@ -64,7 +64,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/form/form-field/nested-path.tsx
+++ b/docs/pages/form/form-field/nested-path.tsx
@@ -24,7 +24,7 @@ export function NestedPath() {
 
         return errors
       }}
-      classes={{ root: 'mx-auto max-w-xl w-full space-y-4' }}
+      class={'mx-auto max-w-xl w-full space-y-4'}
     >
       <FormField name={['profile', 'name']} label="Profile Name" required>
         <Input

--- a/docs/pages/form/form-field/nested-path.tsx
+++ b/docs/pages/form/form-field/nested-path.tsx
@@ -24,7 +24,7 @@ export function NestedPath() {
 
         return errors
       }}
-      class={'mx-auto max-w-xl w-full space-y-4'}
+      class="mx-auto max-w-xl w-full space-y-4"
     >
       <FormField name={['profile', 'name']} label="Profile Name" required>
         <Input

--- a/docs/pages/form/form-field/render-context.tsx
+++ b/docs/pages/form/form-field/render-context.tsx
@@ -15,7 +15,7 @@ export function RenderContext() {
         }
         return []
       }}
-      class={'mx-auto max-w-xl w-full space-y-4'}
+      class="mx-auto max-w-xl w-full space-y-4"
     >
       <FormField name="releaseTitle" label="Release Title" required>
         {(props) => (

--- a/docs/pages/form/form-field/render-context.tsx
+++ b/docs/pages/form/form-field/render-context.tsx
@@ -15,7 +15,7 @@ export function RenderContext() {
         }
         return []
       }}
-      classes={{ root: 'mx-auto max-w-xl w-full space-y-4' }}
+      class={'mx-auto max-w-xl w-full space-y-4'}
     >
       <FormField name="releaseTitle" label="Release Title" required>
         {(props) => (

--- a/docs/pages/form/form-field/with-validation.tsx
+++ b/docs/pages/form/form-field/with-validation.tsx
@@ -20,7 +20,7 @@ export function WithValidation() {
 
         return errors
       }}
-      classes={{ root: 'mx-auto max-w-xl w-full space-y-4' }}
+      class={'mx-auto max-w-xl w-full space-y-4'}
     >
       <FormField name="email" label="Owner Email" required>
         <Input

--- a/docs/pages/form/form-field/with-validation.tsx
+++ b/docs/pages/form/form-field/with-validation.tsx
@@ -20,7 +20,7 @@ export function WithValidation() {
 
         return errors
       }}
-      class={'mx-auto max-w-xl w-full space-y-4'}
+      class="mx-auto max-w-xl w-full space-y-4"
     >
       <FormField name="email" label="Owner Email" required>
         <Input

--- a/docs/pages/form/form/access-request-review.tsx
+++ b/docs/pages/form/form/access-request-review.tsx
@@ -38,7 +38,7 @@ export function AccessRequestReview() {
 
         return errors
       }}
-      classes={{ root: 'mx-auto max-w-2xl w-full space-y-4' }}
+      class={'mx-auto max-w-2xl w-full space-y-4'}
     >
       <FormField name="requester" label="Requester" required>
         <Input

--- a/docs/pages/form/form/access-request-review.tsx
+++ b/docs/pages/form/form/access-request-review.tsx
@@ -38,7 +38,7 @@ export function AccessRequestReview() {
 
         return errors
       }}
-      class={'mx-auto max-w-2xl w-full space-y-4'}
+      class="mx-auto max-w-2xl w-full space-y-4"
     >
       <FormField name="requester" label="Requester" required>
         <Input

--- a/docs/pages/form/form/api.json
+++ b/docs/pages/form/form/api.json
@@ -22,6 +22,12 @@
         "description": "Children of the form, can be a render function."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "FormT.Classes | undefined"
@@ -69,6 +75,11 @@
         "required": false,
         "type": "TState | undefined",
         "description": "The state of the form (controlled)."
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/form/form/api.json
+++ b/docs/pages/form/form/api.json
@@ -25,7 +25,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/form/form/incident-escalation-policy.tsx
+++ b/docs/pages/form/form/incident-escalation-policy.tsx
@@ -42,7 +42,7 @@ export function IncidentEscalationPolicy() {
           ),
         }),
       })}
-      class={'mx-auto max-w-2xl w-full space-y-4'}
+      class="mx-auto max-w-2xl w-full space-y-4"
     >
       <FormField name={['policy', 'name']} label="Policy Name" required>
         <Input

--- a/docs/pages/form/form/incident-escalation-policy.tsx
+++ b/docs/pages/form/form/incident-escalation-policy.tsx
@@ -42,7 +42,7 @@ export function IncidentEscalationPolicy() {
           ),
         }),
       })}
-      classes={{ root: 'mx-auto max-w-2xl w-full space-y-4' }}
+      class={'mx-auto max-w-2xl w-full space-y-4'}
     >
       <FormField name={['policy', 'name']} label="Policy Name" required>
         <Input

--- a/docs/pages/form/form/release-readiness-checklist.tsx
+++ b/docs/pages/form/form/release-readiness-checklist.tsx
@@ -14,7 +14,7 @@ export function ReleaseReadinessChecklist() {
         ),
         notes: v.pipe(v.string(), v.minLength(10, 'Add at least 10 characters of release notes.')),
       })}
-      classes={{ root: 'mx-auto max-w-2xl w-full space-y-4' }}
+      class={'mx-auto max-w-2xl w-full space-y-4'}
     >
       <FormField name="releaseVersion" label="Release Version" required>
         <Input placeholder="v2.14.0" />

--- a/docs/pages/form/form/release-readiness-checklist.tsx
+++ b/docs/pages/form/form/release-readiness-checklist.tsx
@@ -14,7 +14,7 @@ export function ReleaseReadinessChecklist() {
         ),
         notes: v.pipe(v.string(), v.minLength(10, 'Add at least 10 characters of release notes.')),
       })}
-      class={'mx-auto max-w-2xl w-full space-y-4'}
+      class="mx-auto max-w-2xl w-full space-y-4"
     >
       <FormField name="releaseVersion" label="Release Version" required>
         <Input placeholder="v2.14.0" />

--- a/docs/pages/form/form/workspace-provisioning.tsx
+++ b/docs/pages/form/form/workspace-provisioning.tsx
@@ -36,7 +36,7 @@ export function WorkspaceProvisioning() {
 
         return errors
       }}
-      class={'mx-auto max-w-2xl w-full space-y-4'}
+      class="mx-auto max-w-2xl w-full space-y-4"
     >
       <FormField name="workspaceName" label="Workspace Name" required>
         <Input

--- a/docs/pages/form/form/workspace-provisioning.tsx
+++ b/docs/pages/form/form/workspace-provisioning.tsx
@@ -36,7 +36,7 @@ export function WorkspaceProvisioning() {
 
         return errors
       }}
-      classes={{ root: 'mx-auto max-w-2xl w-full space-y-4' }}
+      class={'mx-auto max-w-2xl w-full space-y-4'}
     >
       <FormField name="workspaceName" label="Workspace Name" required>
         <Input

--- a/docs/pages/form/input-number/api.json
+++ b/docs/pages/form/input-number/api.json
@@ -42,6 +42,12 @@
         "defaultValue": "0"
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "InputNumberT.Classes | undefined"
@@ -251,6 +257,11 @@
         "type": "number | undefined",
         "description": "The increment/decrement step size.",
         "defaultValue": "1"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/form/input-number/api.json
+++ b/docs/pages/form/input-number/api.json
@@ -45,7 +45,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/form/input/api.json
+++ b/docs/pages/form/input/api.json
@@ -58,7 +58,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/form/input/api.json
+++ b/docs/pages/form/input/api.json
@@ -55,6 +55,12 @@
         "description": "Additional content to render inside the input container."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "InputT.Classes | undefined"
@@ -170,6 +176,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/form/multi-select/api.json
+++ b/docs/pages/form/multi-select/api.json
@@ -104,7 +104,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/form/multi-select/api.json
+++ b/docs/pages/form/multi-select/api.json
@@ -101,6 +101,12 @@
         "description": "Allow creating new tags on Enter when no match is found."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "MultiSelectT.Classes | undefined"
@@ -304,6 +310,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/form/radio-group/api.json
+++ b/docs/pages/form/radio-group/api.json
@@ -52,6 +52,12 @@
   "props": {
     "own": [
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "RadioGroupT.Classes | undefined"
@@ -129,6 +135,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/form/radio-group/api.json
+++ b/docs/pages/form/radio-group/api.json
@@ -55,7 +55,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/form/select/api.json
+++ b/docs/pages/form/select/api.json
@@ -68,6 +68,12 @@
   "props": {
     "own": [
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "SelectT.Classes | undefined"
@@ -253,6 +259,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/form/select/api.json
+++ b/docs/pages/form/select/api.json
@@ -71,7 +71,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/form/slider/api.json
+++ b/docs/pages/form/slider/api.json
@@ -39,6 +39,12 @@
         "defaultValue": "true"
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "SliderT.Classes | undefined"
@@ -142,6 +148,11 @@
         "required": false,
         "type": "number | undefined",
         "description": "Step increment between values.\nWhen omitted, pointer movement is continuous."
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/form/slider/api.json
+++ b/docs/pages/form/slider/api.json
@@ -42,7 +42,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/form/switch/api.json
+++ b/docs/pages/form/switch/api.json
@@ -55,7 +55,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/form/switch/api.json
+++ b/docs/pages/form/switch/api.json
@@ -52,6 +52,12 @@
         "description": "Icon shown when the switch is checked."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "SwitchT.Classes | undefined"
@@ -144,6 +150,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/form/textarea/api.json
+++ b/docs/pages/form/textarea/api.json
@@ -67,6 +67,12 @@
         "description": "Children elements, rendered inside the root below the textarea."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "TextareaT.Classes | undefined"
@@ -188,6 +194,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/form/textarea/api.json
+++ b/docs/pages/form/textarea/api.json
@@ -70,7 +70,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/general/accordion/api.json
+++ b/docs/pages/general/accordion/api.json
@@ -44,6 +44,12 @@
   "props": {
     "own": [
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "AccordionT.Classes | undefined"
@@ -100,6 +106,11 @@
         "required": false,
         "type": "((value: string[]) => void) | undefined",
         "description": "Callback when the expanded item values change."
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/general/accordion/api.json
+++ b/docs/pages/general/accordion/api.json
@@ -47,7 +47,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/general/avatar/api.json
+++ b/docs/pages/general/avatar/api.json
@@ -10,7 +10,7 @@
   "slots": [
     {
       "name": "root",
-      "description": "Avatar frame that controls size, shape, image, fallback, and badge placement."
+      "description": "Avatar frame that controls size, shape, image, fallback, and badge placement, or the container of grouped avatars when multiple items are provided."
     },
     {
       "name": "image",
@@ -29,15 +29,11 @@
       "description": "Status or indicator badge anchored to the avatar frame."
     },
     {
-      "name": "group",
-      "description": "Container that lays out multiple avatars as an overlapping group."
-    },
-    {
-      "name": "groupItem",
+      "name": "item",
       "description": "Individual avatar wrapper used when rendering grouped avatars."
     },
     {
-      "name": "groupCount",
+      "name": "count",
       "description": "Count indicator shown when a group has more avatars than the visible limit."
     }
   ],
@@ -186,6 +182,12 @@
         "ariaAttributes": []
       },
       {
+        "name": "count",
+        "cssVariables": [],
+        "dataAttributes": [],
+        "ariaAttributes": []
+      },
+      {
         "name": "fallback",
         "cssVariables": [],
         "dataAttributes": [],
@@ -198,19 +200,13 @@
         "ariaAttributes": []
       },
       {
-        "name": "group",
-        "cssVariables": [],
-        "dataAttributes": [],
-        "ariaAttributes": []
-      },
-      {
-        "name": "groupCount",
-        "cssVariables": [],
-        "dataAttributes": [],
-        "ariaAttributes": []
-      },
-      {
         "name": "image",
+        "cssVariables": [],
+        "dataAttributes": [],
+        "ariaAttributes": []
+      },
+      {
+        "name": "root",
         "cssVariables": [],
         "dataAttributes": [],
         "ariaAttributes": []

--- a/docs/pages/general/avatar/api.json
+++ b/docs/pages/general/avatar/api.json
@@ -48,7 +48,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/general/avatar/api.json
+++ b/docs/pages/general/avatar/api.json
@@ -49,6 +49,12 @@
         "type": "\"top-left\" | \"top-right\" | \"bottom-left\" | \"bottom-right\" | undefined"
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "AvatarT.Classes | undefined"
@@ -70,6 +76,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/general/badge/api.json
+++ b/docs/pages/general/badge/api.json
@@ -37,7 +37,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/general/badge/api.json
+++ b/docs/pages/general/badge/api.json
@@ -34,6 +34,12 @@
         "description": "Children of the badge."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "BadgeT.Classes | undefined"
@@ -61,6 +67,11 @@
         "type": "string | undefined",
         "description": "Data slot for styling.",
         "defaultValue": "root"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/general/button/api.json
+++ b/docs/pages/general/button/api.json
@@ -43,6 +43,12 @@
         "description": "Children of the button. Supports render function form."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "ButtonT.Classes | undefined"
@@ -84,6 +90,11 @@
         "required": false,
         "type": "string | undefined",
         "description": "Root `data-slot` name"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/general/button/api.json
+++ b/docs/pages/general/button/api.json
@@ -46,7 +46,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/general/card/api.json
+++ b/docs/pages/general/card/api.json
@@ -52,6 +52,12 @@
         "description": "Children of the card."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "CardT.Classes | undefined"
@@ -80,6 +86,11 @@
         "required": false,
         "type": "JSX.Element",
         "description": "Content to render in the header slot, overrides title/description."
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/general/card/api.json
+++ b/docs/pages/general/card/api.json
@@ -55,7 +55,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/general/card/default.tsx
+++ b/docs/pages/general/card/default.tsx
@@ -14,7 +14,7 @@ export function Default() {
       description="Deploy your new project in one-click."
       footer={
         <>
-          <Button class={'w-full'} type="submit">
+          <Button class="w-full" type="submit">
             Deploy
           </Button>
           <div class="text-xs text-muted-foreground m-a flex gap-1 items-center">

--- a/docs/pages/general/card/default.tsx
+++ b/docs/pages/general/card/default.tsx
@@ -14,7 +14,7 @@ export function Default() {
       description="Deploy your new project in one-click."
       footer={
         <>
-          <Button classes={{ root: 'w-full' }} type="submit">
+          <Button class={'w-full'} type="submit">
             Deploy
           </Button>
           <div class="text-xs text-muted-foreground m-a flex gap-1 items-center">
@@ -23,7 +23,8 @@ export function Default() {
           </div>
         </>
       }
-      classes={{ root: 'w-full max-w-xs', footer: 'flex flex-col gap-3' }}
+      class="max-w-xs w-full"
+      classes={{ footer: 'flex flex-col gap-3' }}
     >
       <div class="flex flex-col gap-4">
         <FormField label="Name">

--- a/docs/pages/general/card/sizes.tsx
+++ b/docs/pages/general/card/sizes.tsx
@@ -8,7 +8,7 @@ export function Sizes() {
         title="Small Card"
         description="Compact"
         footer={<Button size="sm">Action</Button>}
-        class={'h-fit max-w-xs'}
+        class="h-fit max-w-xs"
       >
         <p class="text-sm opacity-85">Compact spacing for dense layouts and sidebars.</p>
       </Card>
@@ -17,7 +17,7 @@ export function Sizes() {
         title="Default Card"
         description="Default"
         footer={<Button size="sm">Action</Button>}
-        class={'h-fit max-w-xs'}
+        class="h-fit max-w-xs"
       >
         <p class="text-sm opacity-85">Standard spacing for normal form and dashboard cards.</p>
       </Card>

--- a/docs/pages/general/card/sizes.tsx
+++ b/docs/pages/general/card/sizes.tsx
@@ -8,7 +8,7 @@ export function Sizes() {
         title="Small Card"
         description="Compact"
         footer={<Button size="sm">Action</Button>}
-        classes={{ root: 'max-w-xs h-fit' }}
+        class={'h-fit max-w-xs'}
       >
         <p class="text-sm opacity-85">Compact spacing for dense layouts and sidebars.</p>
       </Card>
@@ -17,7 +17,7 @@ export function Sizes() {
         title="Default Card"
         description="Default"
         footer={<Button size="sm">Action</Button>}
-        classes={{ root: 'max-w-xs h-fit' }}
+        class={'h-fit max-w-xs'}
       >
         <p class="text-sm opacity-85">Standard spacing for normal form and dashboard cards.</p>
       </Card>

--- a/docs/pages/general/card/with-image.tsx
+++ b/docs/pages/general/card/with-image.tsx
@@ -12,7 +12,7 @@ export function WithImage() {
             class="rounded-t-2xl w-full aspect-video object-cover brightness-60 grayscale"
           />
         }
-        footer={<Button class={'w-full'}>Open</Button>}
+        footer={<Button class="w-full">Open</Button>}
       >
         <h3 class="font-semibold">Beautiful Landscape</h3>
         <p class="text-sm text-muted-foreground mt-1">

--- a/docs/pages/general/card/with-image.tsx
+++ b/docs/pages/general/card/with-image.tsx
@@ -12,7 +12,7 @@ export function WithImage() {
             class="rounded-t-2xl w-full aspect-video object-cover brightness-60 grayscale"
           />
         }
-        footer={<Button classes={{ root: 'w-full' }}>Open</Button>}
+        footer={<Button class={'w-full'}>Open</Button>}
       >
         <h3 class="font-semibold">Beautiful Landscape</h3>
         <p class="text-sm text-muted-foreground mt-1">

--- a/docs/pages/general/collapsible/api.json
+++ b/docs/pages/general/collapsible/api.json
@@ -33,7 +33,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/general/collapsible/api.json
+++ b/docs/pages/general/collapsible/api.json
@@ -30,6 +30,12 @@
         "description": "Content to render inside the collapsible."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "CollapsibleT.Classes | undefined"
@@ -71,6 +77,11 @@
         "required": false,
         "type": "JSX.Element | Component<CollapsibleT.RenderTriggerContext>",
         "description": "Custom trigger content or render function.\n- When component has no prop, the whole component will be wrapped with `<button>`\n- When component has props, uncontrolled state must be setup manually via `CollapsibleT.RenderTriggerContext`"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/general/kbd/api.json
+++ b/docs/pages/general/kbd/api.json
@@ -10,7 +10,7 @@
   "slots": [
     {
       "name": "root",
-      "description": "Keyboard shortcut container that groups one or more key tokens."
+      "description": "Wrapper around multiple key tokens.\n\nSingle-value shortcuts render only the `item` slot, so top-level `class` and `style`\nare applied to that item instead."
     },
     {
       "name": "item",
@@ -24,6 +24,12 @@
         "required": false,
         "type": "JSX.Element",
         "description": "Slot between kbds"
+      },
+      {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
       },
       {
         "name": "classes",
@@ -40,6 +46,11 @@
         "required": false,
         "type": "string | undefined",
         "description": "Prefix for data-slot attributes."
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/general/kbd/api.json
+++ b/docs/pages/general/kbd/api.json
@@ -29,7 +29,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/general/progress/api.json
+++ b/docs/pages/general/progress/api.json
@@ -41,6 +41,12 @@
         "type": "\"carousel\" | \"reverse\" | \"swing\" | \"elastic\" | undefined"
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "ProgressT.Classes | undefined"
@@ -86,6 +92,11 @@
         "type": "boolean | undefined",
         "description": "Whether to show the status label.",
         "defaultValue": "false"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/general/progress/api.json
+++ b/docs/pages/general/progress/api.json
@@ -44,7 +44,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/general/resizable/api.json
+++ b/docs/pages/general/resizable/api.json
@@ -35,7 +35,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/general/resizable/api.json
+++ b/docs/pages/general/resizable/api.json
@@ -32,6 +32,12 @@
   "props": {
     "own": [
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "ResizableT.Classes | undefined"
@@ -111,6 +117,11 @@
         "type": "MaybeRenderProp<ResizableT.HandleState>",
         "description": "Custom handle to render.\n- `true`: render built-in handle.\n- `JSX.Element`: render static custom handle content.\n- `(state) => JSX.Element`: render dynamic content by handle state.",
         "defaultValue": "true"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/general/separator/api.json
+++ b/docs/pages/general/separator/api.json
@@ -33,7 +33,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/general/separator/api.json
+++ b/docs/pages/general/separator/api.json
@@ -30,6 +30,12 @@
         "description": "Additional content to render inside the separator (usually between two borders)."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "SeparatorT.Classes | undefined"
@@ -52,6 +58,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/general/separator/with-content-vertical.tsx
+++ b/docs/pages/general/separator/with-content-vertical.tsx
@@ -11,7 +11,7 @@ export function WithContentVertical() {
         <span>Left</span>
         <Separator orientation="vertical" />
         <span>Center</span>
-        <Separator orientation="vertical" type="dashed" classes={{ root: 'text-primary' }} />
+        <Separator orientation="vertical" type="dashed" class={'text-primary'} />
         <span>Right</span>
       </div>
     </div>

--- a/docs/pages/general/separator/with-content-vertical.tsx
+++ b/docs/pages/general/separator/with-content-vertical.tsx
@@ -11,7 +11,7 @@ export function WithContentVertical() {
         <span>Left</span>
         <Separator orientation="vertical" />
         <span>Center</span>
-        <Separator orientation="vertical" type="dashed" class={'text-primary'} />
+        <Separator orientation="vertical" type="dashed" class="text-primary" />
         <span>Right</span>
       </div>
     </div>

--- a/docs/pages/navigation/breadcrumb/api.json
+++ b/docs/pages/navigation/breadcrumb/api.json
@@ -47,6 +47,12 @@
         "defaultValue": "Breadcrumbs"
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "BreadcrumbT.Classes | undefined"
@@ -76,6 +82,11 @@
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined",
         "description": "Size of the breadcrumb items and icons.",
         "defaultValue": "md"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/navigation/breadcrumb/api.json
+++ b/docs/pages/navigation/breadcrumb/api.json
@@ -50,7 +50,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/navigation/command-palette/api.json
+++ b/docs/pages/navigation/command-palette/api.json
@@ -124,7 +124,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/navigation/command-palette/api.json
+++ b/docs/pages/navigation/command-palette/api.json
@@ -121,6 +121,12 @@
         "defaultValue": "icon-chevron-right"
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "CommandPaletteT.Classes | undefined"
@@ -210,6 +216,11 @@
         "required": false,
         "type": "string | undefined",
         "description": "Controlled search term."
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/navigation/pagination/api.json
+++ b/docs/pages/navigation/pagination/api.json
@@ -57,7 +57,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/navigation/pagination/api.json
+++ b/docs/pages/navigation/pagination/api.json
@@ -54,6 +54,12 @@
         "defaultValue": "Pagination"
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "PaginationT.Classes | undefined",
@@ -158,6 +164,11 @@
         "type": "FormFieldSize | undefined",
         "description": "Size of the pagination buttons.",
         "defaultValue": "md"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/navigation/sidebar-frame/api.json
+++ b/docs/pages/navigation/sidebar-frame/api.json
@@ -39,7 +39,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/navigation/sidebar-frame/api.json
+++ b/docs/pages/navigation/sidebar-frame/api.json
@@ -36,6 +36,12 @@
   "props": {
     "own": [
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "SidebarFrameT.Classes | undefined"
@@ -88,6 +94,11 @@
         "name": "side",
         "required": false,
         "type": "\"left\" | \"right\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/navigation/sidebar-frame/basic.tsx
+++ b/docs/pages/navigation/sidebar-frame/basic.tsx
@@ -39,7 +39,7 @@ export function Basic() {
         renderMain={(ctx) => (
           <>
             <div class="flex flex-row items-center">
-              <Button variant="ghost" classes={{ root: 'm-2' }} onClick={() => ctx.toggle()}>
+              <Button variant="ghost" class={'m-2'} onClick={() => ctx.toggle()}>
                 <Icon name="i-lucide-sidebar" />
               </Button>
               <h3 class="text-base font-semibold">Getting Started</h3>

--- a/docs/pages/navigation/sidebar-frame/basic.tsx
+++ b/docs/pages/navigation/sidebar-frame/basic.tsx
@@ -39,7 +39,7 @@ export function Basic() {
         renderMain={(ctx) => (
           <>
             <div class="flex flex-row items-center">
-              <Button variant="ghost" class={'m-2'} onClick={() => ctx.toggle()}>
+              <Button variant="ghost" class="m-2" onClick={() => ctx.toggle()}>
                 <Icon name="i-lucide-sidebar" />
               </Button>
               <h3 class="text-base font-semibold">Getting Started</h3>

--- a/docs/pages/navigation/sidebar-frame/forced-mobile.tsx
+++ b/docs/pages/navigation/sidebar-frame/forced-mobile.tsx
@@ -9,7 +9,7 @@ export function ForcedMobile() {
         renderSidebarBody={(ctx) => (
           <div class="text-sm p-3 h-full overflow-y-auto">
             <p class="text-muted-foreground">This sidebar is rendered inside Sheet.</p>
-            <Button classes={{ root: 'mt-3' }} variant="outline" onClick={() => ctx.setOpen(false)}>
+            <Button class={'mt-3'} variant="outline" onClick={() => ctx.setOpen(false)}>
               Close
             </Button>
           </div>

--- a/docs/pages/navigation/sidebar-frame/forced-mobile.tsx
+++ b/docs/pages/navigation/sidebar-frame/forced-mobile.tsx
@@ -9,7 +9,7 @@ export function ForcedMobile() {
         renderSidebarBody={(ctx) => (
           <div class="text-sm p-3 h-full overflow-y-auto">
             <p class="text-muted-foreground">This sidebar is rendered inside Sheet.</p>
-            <Button class={'mt-3'} variant="outline" onClick={() => ctx.setOpen(false)}>
+            <Button class="mt-3" variant="outline" onClick={() => ctx.setOpen(false)}>
               Close
             </Button>
           </div>

--- a/docs/pages/navigation/stepper/api.json
+++ b/docs/pages/navigation/stepper/api.json
@@ -67,6 +67,12 @@
         "defaultValue": "automatic"
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "StepperT.Classes | undefined"
@@ -127,6 +133,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/navigation/stepper/api.json
+++ b/docs/pages/navigation/stepper/api.json
@@ -70,7 +70,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/navigation/tabs/api.json
+++ b/docs/pages/navigation/tabs/api.json
@@ -51,6 +51,12 @@
         "defaultValue": "automatic"
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "TabsT.Classes | undefined"
@@ -104,6 +110,11 @@
         "name": "size",
         "required": false,
         "type": "\"xs\" | \"sm\" | \"md\" | \"lg\" | \"xl\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/navigation/tabs/api.json
+++ b/docs/pages/navigation/tabs/api.json
@@ -54,7 +54,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/overlay/context-menu/api.json
+++ b/docs/pages/overlay/context-menu/api.json
@@ -88,7 +88,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/overlay/context-menu/api.json
+++ b/docs/pages/overlay/context-menu/api.json
@@ -85,6 +85,12 @@
         "description": "Target area that opens the context menu on right-click or long press."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "ContextMenuT.Classes | undefined"
@@ -176,6 +182,11 @@
         "name": "size",
         "required": false,
         "type": "\"sm\" | \"md\" | \"lg\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/overlay/dialog/api.json
+++ b/docs/pages/overlay/dialog/api.json
@@ -67,7 +67,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/overlay/dialog/api.json
+++ b/docs/pages/overlay/dialog/api.json
@@ -64,6 +64,12 @@
         "description": "Content to render inside the dialog trigger slot."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "DialogT.Classes | undefined",
@@ -161,6 +167,11 @@
         "type": "boolean | undefined",
         "description": "Whether the dialog content body should be scrollable.",
         "defaultValue": "false"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/overlay/dropdown-menu/api.json
+++ b/docs/pages/overlay/dropdown-menu/api.json
@@ -88,7 +88,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/overlay/dropdown-menu/api.json
+++ b/docs/pages/overlay/dropdown-menu/api.json
@@ -85,6 +85,12 @@
         "description": "Trigger content used to open the dropdown menu."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "DropdownMenuT.Classes | undefined"
@@ -176,6 +182,11 @@
         "name": "size",
         "required": false,
         "type": "\"sm\" | \"md\" | \"lg\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/overlay/popover/api.json
+++ b/docs/pages/overlay/popover/api.json
@@ -30,6 +30,12 @@
         "description": "The reference element that triggers the popover."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "PopoverT.Classes | undefined"
@@ -115,6 +121,11 @@
         "name": "side",
         "required": false,
         "type": "\"left\" | \"right\" | \"top\" | \"bottom\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/overlay/popover/api.json
+++ b/docs/pages/overlay/popover/api.json
@@ -33,7 +33,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/overlay/popup/api.json
+++ b/docs/pages/overlay/popup/api.json
@@ -33,7 +33,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/overlay/popup/api.json
+++ b/docs/pages/overlay/popup/api.json
@@ -30,6 +30,12 @@
         "description": "Element that triggers the popup or additional content."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "PopupT.Classes | undefined"
@@ -100,6 +106,11 @@
         "type": "boolean | undefined",
         "description": "Whether to allow scrolling within the popup.",
         "defaultValue": "false"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/overlay/sheet/api.json
+++ b/docs/pages/overlay/sheet/api.json
@@ -77,7 +77,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/overlay/sheet/api.json
+++ b/docs/pages/overlay/sheet/api.json
@@ -74,6 +74,12 @@
         "description": "Trigger element that opens the sheet."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "SheetT.Classes | undefined"
@@ -154,6 +160,11 @@
         "name": "side",
         "required": false,
         "type": "\"left\" | \"right\" | \"top\" | \"bottom\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/overlay/tooltip/api.json
+++ b/docs/pages/overlay/tooltip/api.json
@@ -38,6 +38,12 @@
         "description": "The reference element that triggers the tooltip."
       },
       {
+        "name": "class",
+        "required": false,
+        "type": "ClassValue",
+        "description": "Class applied to the component root element."
+      },
+      {
         "name": "classes",
         "required": false,
         "type": "TooltipT.Classes | undefined"
@@ -106,6 +112,11 @@
         "name": "side",
         "required": false,
         "type": "\"left\" | \"right\" | \"top\" | \"bottom\" | undefined"
+      },
+      {
+        "name": "style",
+        "required": false,
+        "type": "JSX.CSSProperties | undefined"
       },
       {
         "name": "styles",

--- a/docs/pages/overlay/tooltip/api.json
+++ b/docs/pages/overlay/tooltip/api.json
@@ -41,7 +41,7 @@
         "name": "class",
         "required": false,
         "type": "ClassValue",
-        "description": "Class applied to the component root element."
+        "description": "Class applied to the component root or trigger element."
       },
       {
         "name": "classes",

--- a/docs/pages/styling.mdx
+++ b/docs/pages/styling.mdx
@@ -91,14 +91,14 @@ moraineTailwind({
 
 ## Override Component Styles
 
-Most components support `classes` and `styles`. Keys match slot names.
+Use top-level `class` and `style` for the component root. Use `classes` and `styles` for inner slots; keys match slot names.
 
 ```tsx
 import { Button } from 'moraine'
 
 function MyButton() {
   return (
-    <Button classes={{ label: 'bg-green-500' }} styles={{ root: { background: 'red' } }}>
+    <Button class="bg-red-500" style={{ borderColor: 'red' }} classes={{ label: 'bg-green-500' }}>
       Click me
     </Button>
   )

--- a/docs/pages/styling.mdx
+++ b/docs/pages/styling.mdx
@@ -91,7 +91,9 @@ moraineTailwind({
 
 ## Override Component Styles
 
-Use top-level `class` and `style` for the component root in normal components. Overlay components apply top-level `class` and `style` to their trigger, because the floating content is rendered separately. Use `classes` and `styles` for named slots when you need to target a specific inner slot or overlay content; keys match slot names.
+Use top-level `class` and `style` for the component root in normal components. Use `classes` and `styles` for named slots when you need to target a specific inner slot or overlay content; keys match slot names.
+
+- Overlay components apply top-level `class` and `style` to their **trigger** slot, because the floating content is rendered separately.
 
 ```tsx
 import { Button } from 'moraine'

--- a/docs/pages/styling.mdx
+++ b/docs/pages/styling.mdx
@@ -91,7 +91,7 @@ moraineTailwind({
 
 ## Override Component Styles
 
-Use top-level `class` and `style` for the component root. Use `classes` and `styles` for inner slots; keys match slot names.
+Use top-level `class` and `style` for the component root in normal components. Overlay components apply top-level `class` and `style` to their trigger, because the floating content is rendered separately. Use `classes` and `styles` for named slots when you need to target a specific inner slot or overlay content; keys match slot names.
 
 ```tsx
 import { Button } from 'moraine'

--- a/src/elements/accordion/accordion.tsx
+++ b/src/elements/accordion/accordion.tsx
@@ -14,7 +14,6 @@ export namespace AccordionT {
     /**
      * Container that owns the accordion item collection and shared state attributes.
      */
-
     root?: T
 
     /** Wrapper for one accordion entry, including its header trigger and collapsible panel. */

--- a/src/elements/accordion/accordion.tsx
+++ b/src/elements/accordion/accordion.tsx
@@ -273,8 +273,13 @@ export function Accordion(props: AccordionProps): JSX.Element {
       id={rootId()}
       data-slot="root"
       data-disabled={merged.disabled ? '' : undefined}
-      style={merged.styles?.root}
-      class={cn('flex flex-col w-full', merged.disabled && 'effect-dis', merged.classes?.root)}
+      style={{ ...merged.styles?.root, ...merged.style }}
+      class={cn(
+        'flex flex-col w-full',
+        merged.disabled && 'effect-dis',
+        merged.classes?.root,
+        merged.class,
+      )}
     >
       <For each={normalizedItems()}>
         {(entry) => {

--- a/src/elements/accordion/accordion.tsx
+++ b/src/elements/accordion/accordion.tsx
@@ -11,7 +11,11 @@ import type { IconT } from '../icon'
 
 export namespace AccordionT {
   export interface Slot<T = unknown> {
-    /** Container that owns the accordion item collection and shared state attributes. */
+    /**
+     * Container that owns the accordion item collection and shared state attributes.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Wrapper for one accordion entry, including its header trigger and collapsible panel. */

--- a/src/elements/accordion/accordion.tsx
+++ b/src/elements/accordion/accordion.tsx
@@ -13,7 +13,6 @@ export namespace AccordionT {
   export interface Slot<T = unknown> {
     /**
      * Container that owns the accordion item collection and shared state attributes.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/elements/avatar/avatar.test.tsx
+++ b/src/elements/avatar/avatar.test.tsx
@@ -56,15 +56,13 @@ describe('Avatar', () => {
     ))
 
     expect(screen.container.querySelectorAll('[data-slot="root"]')).toHaveLength(0)
-    expect(screen.container.querySelectorAll('[data-slot="group"]')).toHaveLength(0)
   })
 
   test('treats one item as single avatar structure', () => {
     const screen = render(() => <Avatar items={[{ text: 'MR' }]} />)
 
     expect(screen.container.querySelector('[data-slot="root"]')).not.toBeNull()
-    expect(screen.container.querySelector('[data-slot="group"]')).toBeNull()
-    expect(screen.container.querySelector('[data-slot="groupItem"]')).toBeNull()
+    expect(screen.container.querySelector('[data-slot="item"]')).toBeNull()
   })
 
   test('renders fallback first while image is loading', () => {
@@ -223,31 +221,31 @@ describe('Avatar', () => {
       <Avatar max={2} items={[{ text: 'A' }, { text: 'B' }, { text: 'C' }, { text: 'D' }]} />
     ))
 
-    const group = screen.container.querySelector('[data-slot="group"]')
-    const groupCount = screen.container.querySelector('[data-slot="groupCount"]')
+    const root = screen.container.querySelector('[data-slot="root"]')
+    const count = screen.container.querySelector('[data-slot="count"]')
     const fallbacks = Array.from(
-      screen.container.querySelectorAll('[data-slot="groupItem"] [data-slot="fallback"]'),
+      screen.container.querySelectorAll('[data-slot="item"] [data-slot="fallback"]'),
     )
 
-    expect(group).not.toBeNull()
-    expect(groupCount?.textContent).toBe('+2')
+    expect(root).not.toBeNull()
+    expect(count?.textContent).toBe('+2')
     expect(fallbacks).toHaveLength(2)
     expect(fallbacks[0]?.textContent).toBe('B')
     expect(fallbacks[1]?.textContent).toBe('A')
-    expect(group?.className).toContain('flex-row-reverse')
-    expect(group?.className).toContain('justify-end')
-    const groupItem = screen.container.querySelector('[data-slot="groupItem"]')
-    expect(groupItem?.className).toContain('-me-1.5')
+    expect(root?.className).toContain('flex-row-reverse')
+    expect(root?.className).toContain('justify-end')
+    const item = screen.container.querySelector('[data-slot="item"]')
+    expect(item?.className).toContain('-me-1.5')
   })
 
   test('renders all group items when max is absent and reverses order', () => {
     const screen = render(() => <Avatar items={[{ text: 'A' }, { text: 'B' }, { text: 'C' }]} />)
 
     const fallbacks = Array.from(
-      screen.container.querySelectorAll('[data-slot="groupItem"] [data-slot="fallback"]'),
+      screen.container.querySelectorAll('[data-slot="item"] [data-slot="fallback"]'),
     )
 
-    expect(screen.container.querySelector('[data-slot="groupCount"]')).toBeNull()
+    expect(screen.container.querySelector('[data-slot="count"]')).toBeNull()
     expect(fallbacks).toHaveLength(3)
     expect(fallbacks[0]?.textContent).toBe('C')
     expect(fallbacks[1]?.textContent).toBe('B')
@@ -262,8 +260,8 @@ describe('Avatar', () => {
       </>
     ))
 
-    const groupCounts = Array.from(screen.container.querySelectorAll('[data-slot="groupCount"]'))
-    const groupItems = Array.from(screen.container.querySelectorAll('[data-slot="groupItem"]'))
+    const groupCounts = Array.from(screen.container.querySelectorAll('[data-slot="count"]'))
+    const groupItems = Array.from(screen.container.querySelectorAll('[data-slot="item"]'))
 
     expect(groupCounts[0]?.className).toContain('size-6')
     expect(groupCounts[0]?.className).toContain('-me-1')
@@ -313,27 +311,21 @@ describe('Avatar', () => {
       <Avatar
         max={1}
         items={[{ text: 'A' }, { text: 'B' }]}
-        styles={
-          {
-            group: { width: '200px' },
-            groupItem: { width: '200px' },
-            groupCount: { width: '200px' },
-          } as any
-        }
+        styles={{
+          root: { width: '200px' },
+          item: { width: '200px' },
+          count: { width: '200px' },
+        }}
       />
     ))
 
-    const group = screen.container.querySelector('[data-slot="group"]') as HTMLElement | null
-    const groupItem = screen.container.querySelector(
-      '[data-slot="groupItem"]',
-    ) as HTMLElement | null
-    const groupCount = screen.container.querySelector(
-      '[data-slot="groupCount"]',
-    ) as HTMLElement | null
+    const root = screen.container.querySelector('[data-slot="root"]') as HTMLElement | null
+    const item = screen.container.querySelector('[data-slot="item"]') as HTMLElement | null
+    const count = screen.container.querySelector('[data-slot="count"]') as HTMLElement | null
 
-    expect(group?.style.width).toBe('200px')
-    expect(groupItem?.style.width).toBe('200px')
-    expect(groupCount?.style.width).toBe('200px')
+    expect(root?.style.width).toBe('200px')
+    expect(item?.style.width).toBe('200px')
+    expect(count?.style.width).toBe('200px')
   })
 
   test('rejects arbitrary html props while accepting root class prop in type contract', () => {

--- a/src/elements/avatar/avatar.test.tsx
+++ b/src/elements/avatar/avatar.test.tsx
@@ -336,17 +336,16 @@ describe('Avatar', () => {
     expect(groupCount?.style.width).toBe('200px')
   })
 
-  test('rejects arbitrary html props and class prop in type contract', () => {
+  test('rejects arbitrary html props while accepting root class prop in type contract', () => {
     // @ts-expect-error Avatar is sealed and does not accept arbitrary html props.
     const invalidHtmlProps: AvatarProps = { id: 'avatar-id', as: 'div', onclick: () => {} }
-    // @ts-expect-error Avatar uses classes slots instead of class prop.
-    const invalidClassProp: AvatarProps = { class: 'avatar-class' }
+    const validClassProp: AvatarProps = { class: 'avatar-class' }
     // @ts-expect-error Avatar no longer accepts top-level single-item props.
     const invalidSingleProp: AvatarProps = { src: '/avatar.png' }
     const validItemsProp: AvatarProps = { items: [{ icon: 'i-lucide-user' }] }
 
     expect(invalidHtmlProps).toBeDefined()
-    expect(invalidClassProp).toBeDefined()
+    expect(validClassProp).toBeDefined()
     expect(invalidSingleProp).toBeDefined()
     expect(validItemsProp).toBeDefined()
   })

--- a/src/elements/avatar/avatar.tsx
+++ b/src/elements/avatar/avatar.tsx
@@ -22,7 +22,7 @@ type Status = 'idle' | 'loading' | 'loaded' | 'error'
 export namespace AvatarT {
   export interface Slot<T = unknown> {
     /**
-     * Avatar frame that controls size, shape, image, fallback, and badge placement.
+     * Avatar frame that controls size, shape, image, fallback, and badge placement, or the container of grouped avatars when multiple items are provided.
      */
     root?: T
 
@@ -38,14 +38,11 @@ export namespace AvatarT {
     /** Status or indicator badge anchored to the avatar frame. */
     badge?: T
 
-    /** Container that lays out multiple avatars as an overlapping group. */
-    group?: T
-
     /** Individual avatar wrapper used when rendering grouped avatars. */
-    groupItem?: T
+    item?: T
 
     /** Count indicator shown when a group has more avatars than the visible limit. */
-    groupCount?: T
+    count?: T
   }
   export type Variant = AvatarVariantProps
   export type Classes = Slot<SlotClassValue>
@@ -182,7 +179,7 @@ export function Avatar(props: AvatarProps): JSX.Element {
     return merged.items.length - visibleItems().length
   })
 
-  function AvatarFace(props: AvatarT.Item & { slot: 'root' | 'groupItem' }): JSX.Element {
+  function AvatarFace(props: AvatarT.Item & { slot: 'root' | 'item' }): JSX.Element {
     const [status, setStatusSignal] = createSignal<Status>('idle')
     const [resolvedSrc, setResolvedSrc] = createSignal<string | undefined>(undefined)
 
@@ -239,25 +236,15 @@ export function Avatar(props: AvatarProps): JSX.Element {
       <span
         data-slot={props.slot}
         data-status={status()}
-        style={
-          props.slot === 'groupItem'
-            ? { ...merged.styles?.groupItem, ...merged.style }
-            : { ...merged.styles?.root, ...merged.style }
-        }
+        style={{
+          ...merged.styles,
+          ...(props.slot === 'item' ? merged.styles?.item : merged.styles?.root),
+        }}
         class={avatarRootVariants(
-          {
-            size: merged.size,
-          },
-          props.slot === 'groupItem'
-            ? avatarGroupItemVariants(
-                {
-                  size: merged.size,
-                },
-                merged.classes?.root,
-                merged.classes?.groupItem,
-              )
-            : merged.classes?.root,
-          merged.class,
+          { size: merged.size },
+          props.slot === 'item'
+            ? avatarGroupItemVariants({ size: merged.size }, merged.classes?.item)
+            : [merged.classes?.root, merged.class],
         )}
       >
         <img
@@ -332,26 +319,26 @@ export function Avatar(props: AvatarProps): JSX.Element {
       }
     >
       <div
-        data-slot="group"
-        style={merged.styles?.group}
-        class={cn('inline-flex flex-row-reverse justify-end', merged.classes?.group)}
+        data-slot="root"
+        style={merged.styles?.root}
+        class={cn('inline-flex flex-row-reverse justify-end', merged.classes?.root)}
       >
         <Show when={hiddenCount() > 0}>
           <span
-            data-slot="groupCount"
-            style={merged.styles?.groupCount}
+            data-slot="count"
+            style={merged.styles?.count}
             class={avatarGroupCountVariants(
               {
                 size: merged.size,
               },
-              merged.classes?.groupCount,
+              merged.classes?.count,
             )}
           >
             +{hiddenCount()}
           </span>
         </Show>
 
-        <For each={visibleItems()}>{(item) => <AvatarFace {...item} slot="groupItem" />}</For>
+        <For each={visibleItems()}>{(item) => <AvatarFace {...item} slot="item" />}</For>
       </div>
     </Show>
   )

--- a/src/elements/avatar/avatar.tsx
+++ b/src/elements/avatar/avatar.tsx
@@ -24,7 +24,6 @@ export namespace AvatarT {
     /**
      * Avatar frame that controls size, shape, image, fallback, and badge placement.
      */
-
     root?: T
 
     /** Loaded avatar image rendered inside the frame. */

--- a/src/elements/avatar/avatar.tsx
+++ b/src/elements/avatar/avatar.tsx
@@ -237,8 +237,8 @@ export function Avatar(props: AvatarProps): JSX.Element {
         data-slot={props.slot}
         data-status={status()}
         style={{
-          ...merged.styles,
           ...(props.slot === 'item' ? merged.styles?.item : merged.styles?.root),
+          ...merged.style,
         }}
         class={avatarRootVariants(
           { size: merged.size },
@@ -320,8 +320,8 @@ export function Avatar(props: AvatarProps): JSX.Element {
     >
       <div
         data-slot="root"
-        style={merged.styles?.root}
-        class={cn('inline-flex flex-row-reverse justify-end', merged.classes?.root)}
+        style={{ ...merged.styles?.root, ...merged.style }}
+        class={cn('inline-flex flex-row-reverse justify-end', merged.classes?.root, merged.class)}
       >
         <Show when={hiddenCount() > 0}>
           <span

--- a/src/elements/avatar/avatar.tsx
+++ b/src/elements/avatar/avatar.tsx
@@ -23,7 +23,6 @@ export namespace AvatarT {
   export interface Slot<T = unknown> {
     /**
      * Avatar frame that controls size, shape, image, fallback, and badge placement.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/elements/avatar/avatar.tsx
+++ b/src/elements/avatar/avatar.tsx
@@ -237,7 +237,11 @@ export function Avatar(props: AvatarProps): JSX.Element {
       <span
         data-slot={props.slot}
         data-status={status()}
-        style={props.slot === 'groupItem' ? merged.styles?.groupItem : merged.styles?.root}
+        style={
+          props.slot === 'groupItem'
+            ? { ...merged.styles?.groupItem, ...merged.style }
+            : { ...merged.styles?.root, ...merged.style }
+        }
         class={avatarRootVariants(
           {
             size: merged.size,
@@ -251,6 +255,7 @@ export function Avatar(props: AvatarProps): JSX.Element {
                 merged.classes?.groupItem,
               )
             : merged.classes?.root,
+          merged.class,
         )}
       >
         <img

--- a/src/elements/avatar/avatar.tsx
+++ b/src/elements/avatar/avatar.tsx
@@ -21,7 +21,11 @@ type Status = 'idle' | 'loading' | 'loaded' | 'error'
 
 export namespace AvatarT {
   export interface Slot<T = unknown> {
-    /** Avatar frame that controls size, shape, image, fallback, and badge placement. */
+    /**
+     * Avatar frame that controls size, shape, image, fallback, and badge placement.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Loaded avatar image rendered inside the frame. */

--- a/src/elements/badge/badge.tsx
+++ b/src/elements/badge/badge.tsx
@@ -101,13 +101,14 @@ export function Badge(props: BadgeProps): JSX.Element {
       data-size={merged.size}
       data-variant={merged.variant}
       title={merged.title}
-      style={merged.styles?.root}
+      style={{ ...merged.styles?.root, ...merged.style }}
       class={badgeVariants(
         {
           size: merged.size,
           variant: merged.variant,
         },
         merged.classes?.root,
+        merged.class,
       )}
       onPointerDown={(e) => {
         e.preventDefault()

--- a/src/elements/badge/badge.tsx
+++ b/src/elements/badge/badge.tsx
@@ -21,7 +21,6 @@ export namespace BadgeT {
     /**
      * Inline badge container that carries the variant, size, and interactive state.
      */
-
     root?: T
 
     /** Optional icon displayed before the badge label. */

--- a/src/elements/badge/badge.tsx
+++ b/src/elements/badge/badge.tsx
@@ -20,7 +20,6 @@ export namespace BadgeT {
   export interface Slot<T = unknown> {
     /**
      * Inline badge container that carries the variant, size, and interactive state.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/elements/badge/badge.tsx
+++ b/src/elements/badge/badge.tsx
@@ -18,7 +18,11 @@ export namespace BadgeT {
   > {}
 
   export interface Slot<T = unknown> {
-    /** Inline badge container that carries the variant, size, and interactive state. */
+    /**
+     * Inline badge container that carries the variant, size, and interactive state.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Optional icon displayed before the badge label. */
@@ -153,8 +157,8 @@ export function Badge(props: BadgeProps): JSX.Element {
               name={trailing()}
               size={merged.size}
               data-slot="trailing"
-              styles={{ root: merged.styles?.trailing }}
-              classes={{ root: cn('ms-.5', merged.classes?.trailing) }}
+              style={merged.styles?.trailing}
+              class={cn('ms-.5', merged.classes?.trailing)}
               onClick={merged.onTrailingClick}
             />
           </Show>

--- a/src/elements/button/button.tsx
+++ b/src/elements/button/button.tsx
@@ -15,7 +15,11 @@ import { buttonVariants } from './button.class'
 
 export namespace ButtonT {
   export interface Slot<T = unknown> {
-    /** Interactive button element, or the polymorphic element provided through `as`. */
+    /**
+     * Interactive button element, or the polymorphic element provided through `as`.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Loading icon shown while the button is busy. */

--- a/src/elements/button/button.tsx
+++ b/src/elements/button/button.tsx
@@ -110,6 +110,8 @@ export function Button<T extends ValidComponent = 'button'>(props: ButtonProps<T
     'size',
     'classes',
     'styles',
+    'class',
+    'style',
     'slotName',
     'disabled',
     'loading',
@@ -223,13 +225,14 @@ export function Button<T extends ValidComponent = 'button'>(props: ButtonProps<T
     <Dynamic
       component={tag()}
       data-slot={local.slotName || 'root'}
-      style={local.styles?.root}
+      style={{ ...local.styles?.root, ...local.style }}
       class={buttonVariants(
         {
           variant: local.variant,
           size: local.size,
         },
         local.classes?.root,
+        local.class,
       )}
       type={isNativeBtn() ? 'button' : undefined}
       role={needsButtonRole() ? 'button' : undefined}

--- a/src/elements/button/button.tsx
+++ b/src/elements/button/button.tsx
@@ -17,7 +17,6 @@ export namespace ButtonT {
   export interface Slot<T = unknown> {
     /**
      * Interactive button element, or the polymorphic element provided through `as`.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/elements/button/button.tsx
+++ b/src/elements/button/button.tsx
@@ -18,7 +18,6 @@ export namespace ButtonT {
     /**
      * Interactive button element, or the polymorphic element provided through `as`.
      */
-
     root?: T
 
     /** Loading icon shown while the button is busy. */

--- a/src/elements/card/card.tsx
+++ b/src/elements/card/card.tsx
@@ -8,7 +8,6 @@ export namespace CardT {
   export interface Slot<T = unknown> {
     /**
      * Card container that frames the header, body, and footer regions.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/elements/card/card.tsx
+++ b/src/elements/card/card.tsx
@@ -6,7 +6,11 @@ import { cn } from '../../shared/utils'
 
 export namespace CardT {
   export interface Slot<T = unknown> {
-    /** Card container that frames the header, body, and footer regions. */
+    /**
+     * Card container that frames the header, body, and footer regions.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Top region for title, description, custom header content, and actions. */

--- a/src/elements/card/card.tsx
+++ b/src/elements/card/card.tsx
@@ -90,10 +90,11 @@ export function Card(props: CardProps): JSX.Element {
   return (
     <div
       data-slot="root"
-      style={props.styles?.root}
+      style={{ ...props.styles?.root, ...props.style }}
       class={cn(
         'text-card-foreground surface-border rounded-2xl bg-card flex flex-col shadow-xs/5 relative not-dark:bg-clip-padding',
         props.classes?.root,
+        props.class,
       )}
     >
       <Show when={props.header || props.title || props.description}>

--- a/src/elements/card/card.tsx
+++ b/src/elements/card/card.tsx
@@ -9,7 +9,6 @@ export namespace CardT {
     /**
      * Card container that frames the header, body, and footer regions.
      */
-
     root?: T
 
     /** Top region for title, description, custom header content, and actions. */

--- a/src/elements/collapsible/collapsible.tsx
+++ b/src/elements/collapsible/collapsible.tsx
@@ -69,7 +69,6 @@ export namespace CollapsibleT {
   export interface Slot<T = unknown> {
     /**
      * Container that owns the trigger and expandable content state.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/elements/collapsible/collapsible.tsx
+++ b/src/elements/collapsible/collapsible.tsx
@@ -227,8 +227,8 @@ export function Collapsible(props: CollapsibleProps): JSX.Element {
     <div
       id={rootId()}
       data-slot="root"
-      style={props.styles?.root}
-      class={cn(props.classes?.root)}
+      style={{ ...props.styles?.root, ...props.style }}
+      class={cn(props.classes?.root, props.class)}
       {...dataAttrs()}
     >
       <Show

--- a/src/elements/collapsible/collapsible.tsx
+++ b/src/elements/collapsible/collapsible.tsx
@@ -67,7 +67,11 @@ export namespace CollapsibleT {
   }
 
   export interface Slot<T = unknown> {
-    /** Container that owns the trigger and expandable content state. */
+    /**
+     * Container that owns the trigger and expandable content state.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Button users activate to toggle the content visibility. */

--- a/src/elements/collapsible/collapsible.tsx
+++ b/src/elements/collapsible/collapsible.tsx
@@ -70,7 +70,6 @@ export namespace CollapsibleT {
     /**
      * Container that owns the trigger and expandable content state.
      */
-
     root?: T
 
     /** Button users activate to toggle the content visibility. */

--- a/src/elements/icon/icon-button-inner.tsx
+++ b/src/elements/icon/icon-button-inner.tsx
@@ -10,7 +10,11 @@ import type { IconButtonVariantProps } from './icon-button.class'
 
 export namespace IconButtonInnerT {
   export interface Slot<T = unknown> {
-    /** Internal icon-only button shell used by composed components. */
+    /**
+     * Internal icon-only button shell used by composed components.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Icon glyph rendered inside the internal button shell. */

--- a/src/elements/icon/icon-button-inner.tsx
+++ b/src/elements/icon/icon-button-inner.tsx
@@ -13,7 +13,6 @@ export namespace IconButtonInnerT {
     /**
      * Internal icon-only button shell used by composed components.
      */
-
     root?: T
 
     /** Icon glyph rendered inside the internal button shell. */

--- a/src/elements/icon/icon-button-inner.tsx
+++ b/src/elements/icon/icon-button-inner.tsx
@@ -12,7 +12,6 @@ export namespace IconButtonInnerT {
   export interface Slot<T = unknown> {
     /**
      * Internal icon-only button shell used by composed components.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/elements/icon/icon-button-inner.tsx
+++ b/src/elements/icon/icon-button-inner.tsx
@@ -52,6 +52,8 @@ export function IconButtonInner(props: IconButtonInnerProps): JSX.Element {
   const [local, rest] = splitProps(props, [
     'classes',
     'styles',
+    'class',
+    'style',
     'name',
     'size',
     'slotName',
@@ -62,8 +64,8 @@ export function IconButtonInner(props: IconButtonInnerProps): JSX.Element {
     <button
       data-slot={local.slotName ?? 'root'}
       type="button"
-      class={iconButtonVariants({ size: local.size }, local.classes?.root)}
-      style={local.styles?.root}
+      class={iconButtonVariants({ size: local.size }, local.classes?.root, local.class)}
+      style={{ ...local.styles?.root, ...local.style }}
       {...rest}
     >
       <Icon

--- a/src/elements/icon/icon-button.tsx
+++ b/src/elements/icon/icon-button.tsx
@@ -14,7 +14,6 @@ export namespace IconButtonT {
     /**
      * Icon-only button element that owns loading, disabled, and interaction state.
      */
-
     root?: T
 
     /** Icon glyph rendered inside the button, including the loading icon when active. */

--- a/src/elements/icon/icon-button.tsx
+++ b/src/elements/icon/icon-button.tsx
@@ -13,7 +13,6 @@ export namespace IconButtonT {
   export interface Slot<T = unknown> {
     /**
      * Icon-only button element that owns loading, disabled, and interaction state.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/elements/icon/icon-button.tsx
+++ b/src/elements/icon/icon-button.tsx
@@ -69,6 +69,8 @@ export interface IconButtonProps extends IconButtonT.Props {}
  */
 export function IconButton(props: IconButtonProps): JSX.Element {
   const [local, rest] = splitProps(props, [
+    'class',
+    'style',
     'classes',
     'styles',
     'name',
@@ -91,10 +93,13 @@ export function IconButton(props: IconButtonProps): JSX.Element {
       {...rest}
       name={isLoading() ? (local.loadingIcon ?? 'icon-loading') : local.name}
       size={local.size}
-      class={local.classes?.root}
-      classes={{ icon: cn(isLoading() && 'effect-loading', local.classes?.icon) }}
-      style={local.styles?.root}
-      styles={{ icon: local.styles?.icon }}
+      class={local.class}
+      classes={{
+        root: local.classes?.root,
+        icon: cn(isLoading() && 'effect-loading', local.classes?.icon),
+      }}
+      style={local.style}
+      styles={local.styles}
       aria-busy={isLoading() || undefined}
       data-loading={isLoading() ? '' : undefined}
       disabled={isLoading() || local.disabled}

--- a/src/elements/icon/icon-button.tsx
+++ b/src/elements/icon/icon-button.tsx
@@ -11,7 +11,11 @@ import type { IconButtonVariantProps } from './icon-button.class'
 
 export namespace IconButtonT {
   export interface Slot<T = unknown> {
-    /** Icon-only button element that owns loading, disabled, and interaction state. */
+    /**
+     * Icon-only button element that owns loading, disabled, and interaction state.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Icon glyph rendered inside the button, including the loading icon when active. */
@@ -89,11 +93,10 @@ export function IconButton(props: IconButtonProps): JSX.Element {
       {...rest}
       name={isLoading() ? (local.loadingIcon ?? 'icon-loading') : local.name}
       size={local.size}
-      classes={{
-        root: local.classes?.root,
-        icon: cn(isLoading() && 'effect-loading', local.classes?.icon),
-      }}
-      styles={local.styles}
+      class={local.classes?.root}
+      classes={{ icon: cn(isLoading() && 'effect-loading', local.classes?.icon) }}
+      style={local.styles?.root}
+      styles={{ icon: local.styles?.icon }}
       aria-busy={isLoading() || undefined}
       data-loading={isLoading() ? '' : undefined}
       disabled={isLoading() || local.disabled}

--- a/src/elements/kbd/kbd.test.tsx
+++ b/src/elements/kbd/kbd.test.tsx
@@ -81,6 +81,28 @@ describe('Kbd', () => {
     expect(item?.style.width).toBe('200px')
   })
 
+  test('applies top-level class and style to single item shortcuts', () => {
+    const screen = render(() => <Kbd value={['K']} class="shortcut" style={{ width: '200px' }} />)
+    const item = screen.container.querySelector('[data-slot="kbd"]') as HTMLElement | null
+
+    expect(screen.container.querySelector('[data-slot="kbds"]')).toBeNull()
+    expect(item?.className).toContain('shortcut')
+    expect(item?.style.width).toBe('200px')
+  })
+
+  test('applies top-level class and style to multiple item wrapper', () => {
+    const screen = render(() => (
+      <Kbd value={['Ctrl', 'K']} class="shortcut" style={{ width: '200px' }} />
+    ))
+    const root = screen.container.querySelector('[data-slot="kbds"]') as HTMLElement | null
+    const item = screen.container.querySelector('[data-slot="kbd"]') as HTMLElement | null
+
+    expect(root?.className).toContain('shortcut')
+    expect(root?.style.width).toBe('200px')
+    expect(item?.className).not.toContain('shortcut')
+    expect(item?.style.width).toBe('')
+  })
+
   test('keeps explicit data-slot support for item slot', () => {
     const screen = render(() => <Kbd value={['K', 'S']} slotPrefix="item" />)
     const root = screen.container.querySelector('[data-slot="item-kbds"]')

--- a/src/elements/kbd/kbd.tsx
+++ b/src/elements/kbd/kbd.tsx
@@ -9,7 +9,11 @@ import { kbdItemVariants } from './kbd.class'
 
 export namespace KbdT {
   export interface Slot<T = unknown> {
-    /** Keyboard shortcut container that groups one or more key tokens. */
+    /**
+     * Keyboard shortcut container that groups one or more key tokens.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Individual key token inside the shortcut sequence. */

--- a/src/elements/kbd/kbd.tsx
+++ b/src/elements/kbd/kbd.tsx
@@ -11,7 +11,6 @@ export namespace KbdT {
   export interface Slot<T = unknown> {
     /**
      * Keyboard shortcut container that groups one or more key tokens.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/elements/kbd/kbd.tsx
+++ b/src/elements/kbd/kbd.tsx
@@ -15,7 +15,6 @@ export namespace KbdT {
      * Single-value shortcuts render only the `item` slot, so top-level `class` and `style`
      * are applied to that item instead.
      */
-
     root?: T
 
     /** Individual key token inside the shortcut sequence. */
@@ -60,12 +59,7 @@ export interface KbdProps extends KbdT.Props {}
 
 /** Keyboard shortcut display component with configurable size and variant. */
 export function Kbd(props: KbdProps): JSX.Element {
-  const Inner = (innerProps: {
-    val: string
-    append?: boolean
-    class?: SlotClassValue
-    style?: JSX.CSSProperties
-  }) => (
+  const Inner = (innerProps: { val: string; append?: boolean; topLevel?: boolean }) => (
     <>
       <kbd
         data-slot={props.slotPrefix ? `${props.slotPrefix}-kbd` : 'kbd'}
@@ -74,10 +68,9 @@ export function Kbd(props: KbdProps): JSX.Element {
             size: props.size,
             variant: props.variant,
           },
-          props.classes?.item,
-          innerProps.class,
+          innerProps.topLevel ? props.class : props.classes?.item,
         )}
-        style={{ ...props.styles?.item, ...innerProps.style }}
+        style={innerProps.topLevel ? props.style : props.styles?.item}
       >
         {innerProps.val}
       </kbd>
@@ -87,9 +80,7 @@ export function Kbd(props: KbdProps): JSX.Element {
   return (
     <Show when={props.value}>
       <Switch>
-        <Match when={props.value!.length === 1}>
-          {<Inner val={props.value![0]!} class={props.class} style={props.style} />}
-        </Match>
+        <Match when={props.value!.length === 1}>{<Inner val={props.value![0]!} topLevel />}</Match>
         <Match when={props.value!.length > 1}>
           <span
             data-slot={props.slotPrefix ? `${props.slotPrefix}-kbds` : 'kbds'}

--- a/src/elements/kbd/kbd.tsx
+++ b/src/elements/kbd/kbd.tsx
@@ -10,7 +10,10 @@ import { kbdItemVariants } from './kbd.class'
 export namespace KbdT {
   export interface Slot<T = unknown> {
     /**
-     * Keyboard shortcut container that groups one or more key tokens.
+     * Wrapper around multiple key tokens.
+     *
+     * Single-value shortcuts render only the `item` slot, so top-level `class` and `style`
+     * are applied to that item instead.
      */
 
     root?: T
@@ -57,7 +60,12 @@ export interface KbdProps extends KbdT.Props {}
 
 /** Keyboard shortcut display component with configurable size and variant. */
 export function Kbd(props: KbdProps): JSX.Element {
-  const Inner = (innerProps: { val: string; append?: boolean }) => (
+  const Inner = (innerProps: {
+    val: string
+    append?: boolean
+    class?: SlotClassValue
+    style?: JSX.CSSProperties
+  }) => (
     <>
       <kbd
         data-slot={props.slotPrefix ? `${props.slotPrefix}-kbd` : 'kbd'}
@@ -67,8 +75,9 @@ export function Kbd(props: KbdProps): JSX.Element {
             variant: props.variant,
           },
           props.classes?.item,
+          innerProps.class,
         )}
-        style={props.styles?.item}
+        style={{ ...props.styles?.item, ...innerProps.style }}
       >
         {innerProps.val}
       </kbd>
@@ -78,7 +87,9 @@ export function Kbd(props: KbdProps): JSX.Element {
   return (
     <Show when={props.value}>
       <Switch>
-        <Match when={props.value!.length === 1}>{<Inner val={props.value![0]!} />}</Match>
+        <Match when={props.value!.length === 1}>
+          {<Inner val={props.value![0]!} class={props.class} style={props.style} />}
+        </Match>
         <Match when={props.value!.length > 1}>
           <span
             data-slot={props.slotPrefix ? `${props.slotPrefix}-kbds` : 'kbds'}

--- a/src/elements/kbd/kbd.tsx
+++ b/src/elements/kbd/kbd.tsx
@@ -79,8 +79,8 @@ export function Kbd(props: KbdProps): JSX.Element {
         <Match when={props.value!.length > 1}>
           <span
             data-slot={props.slotPrefix ? `${props.slotPrefix}-kbds` : 'kbds'}
-            class={cn('inline-flex gap-1 items-center', props.classes?.root)}
-            style={props.styles?.root}
+            class={cn('inline-flex gap-1 items-center', props.classes?.root, props.class)}
+            style={{ ...props.styles?.root, ...props.style }}
           >
             <For each={props.value}>
               {(value, idx) => <Inner val={value} append={idx() < props.value!.length - 1} />}

--- a/src/elements/progress/progress.tsx
+++ b/src/elements/progress/progress.tsx
@@ -39,7 +39,6 @@ export namespace ProgressT {
   export interface Slot<T = unknown> {
     /**
      * Progress container that owns track, indicator, labels, and step markers.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/elements/progress/progress.tsx
+++ b/src/elements/progress/progress.tsx
@@ -40,7 +40,6 @@ export namespace ProgressT {
     /**
      * Progress container that owns track, indicator, labels, and step markers.
      */
-
     root?: T
 
     /** Text region that displays the current progress status. */

--- a/src/elements/progress/progress.tsx
+++ b/src/elements/progress/progress.tsx
@@ -250,7 +250,7 @@ export function Progress(props: ProgressProps): JSX.Element {
       aria-valuenow={isIndeterminate() ? undefined : resolvedValue()}
       aria-valuetext={valueText()}
       data-slot="root"
-      style={merged.styles?.root}
+      style={{ ...merged.styles?.root, ...merged.style }}
       data-orientation={merged.orientation}
       {...dataAttrs()}
       class={progressRootVariants(
@@ -258,6 +258,7 @@ export function Progress(props: ProgressProps): JSX.Element {
           orientation: merged.orientation,
         },
         merged.classes?.root,
+        merged.class,
       )}
     >
       <Show when={!isIndeterminate() && (merged.status || merged.renderStatus)}>

--- a/src/elements/progress/progress.tsx
+++ b/src/elements/progress/progress.tsx
@@ -37,7 +37,11 @@ export namespace ProgressT {
   }
 
   export interface Slot<T = unknown> {
-    /** Progress container that owns track, indicator, labels, and step markers. */
+    /**
+     * Progress container that owns track, indicator, labels, and step markers.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Text region that displays the current progress status. */

--- a/src/elements/resizable/resizable.tsx
+++ b/src/elements/resizable/resizable.tsx
@@ -55,7 +55,11 @@ export namespace ResizableT {
   }
 
   export interface Slot<T = unknown> {
-    /** Layout container that owns resizable panels and handles. */
+    /**
+     * Layout container that owns resizable panels and handles.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Content pane whose size is controlled by adjacent resize handles. */

--- a/src/elements/resizable/resizable.tsx
+++ b/src/elements/resizable/resizable.tsx
@@ -58,7 +58,6 @@ export namespace ResizableT {
     /**
      * Layout container that owns resizable panels and handles.
      */
-
     root?: T
 
     /** Content pane whose size is controlled by adjacent resize handles. */

--- a/src/elements/resizable/resizable.tsx
+++ b/src/elements/resizable/resizable.tsx
@@ -57,7 +57,6 @@ export namespace ResizableT {
   export interface Slot<T = unknown> {
     /**
      * Layout container that owns resizable panels and handles.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/elements/resizable/resizable.tsx
+++ b/src/elements/resizable/resizable.tsx
@@ -730,10 +730,14 @@ export function Resizable(props: ResizableProps): JSX.Element {
       ref={rootRef}
       id={local.id}
       data-slot="root"
-      style={local.styles?.root}
+      style={{ ...local.styles?.root, ...local.style }}
       data-resizable-root
       data-orientation={orientation()}
-      class={resizableRootVariants({ orientation: orientation() }, local.classes?.root)}
+      class={resizableRootVariants(
+        { orientation: orientation() },
+        local.classes?.root,
+        local.class,
+      )}
     >
       <Index each={resolvedPanels()}>
         {(panel, index) => {

--- a/src/elements/separator/separator.tsx
+++ b/src/elements/separator/separator.tsx
@@ -12,7 +12,11 @@ import {
 
 export namespace SeparatorT {
   export interface Slot<T = unknown> {
-    /** Separator line container, including optional label content. */
+    /**
+     * Separator line container, including optional label content.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Visual line segment rendered around optional separator content. */

--- a/src/elements/separator/separator.tsx
+++ b/src/elements/separator/separator.tsx
@@ -15,7 +15,6 @@ export namespace SeparatorT {
     /**
      * Separator line container, including optional label content.
      */
-
     root?: T
 
     /** Visual line segment rendered around optional separator content. */

--- a/src/elements/separator/separator.tsx
+++ b/src/elements/separator/separator.tsx
@@ -14,7 +14,6 @@ export namespace SeparatorT {
   export interface Slot<T = unknown> {
     /**
      * Separator line container, including optional label content.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/elements/separator/separator.tsx
+++ b/src/elements/separator/separator.tsx
@@ -78,8 +78,12 @@ export function Separator(props: SeparatorProps): JSX.Element {
       data-orientation={merged.orientation}
       aria-orientation={merged.orientation === 'vertical' ? 'vertical' : undefined}
       aria-hidden={merged.decorative ? true : undefined}
-      style={merged.styles?.root}
-      class={separatorRootVariants({ orientation: merged.orientation }, merged.classes?.root)}
+      style={{ ...merged.styles?.root, ...merged.style }}
+      class={separatorRootVariants(
+        { orientation: merged.orientation },
+        merged.classes?.root,
+        merged.class,
+      )}
     >
       <div
         data-slot="border"

--- a/src/forms/checkbox-group/checkbox-group.tsx
+++ b/src/forms/checkbox-group/checkbox-group.tsx
@@ -271,8 +271,8 @@ export function CheckboxGroup<TTrue = boolean, TFalse = boolean>(
     <div
       id={`${groupId()}-root`}
       data-slot="root"
-      style={merged.styles?.root}
-      class={cn('relative', merged.classes?.root)}
+      style={{ ...merged.styles?.root, ...merged.style }}
+      class={cn('relative', merged.classes?.root, merged.class)}
     >
       <fieldset
         ref={(element) => {

--- a/src/forms/checkbox-group/checkbox-group.tsx
+++ b/src/forms/checkbox-group/checkbox-group.tsx
@@ -27,7 +27,6 @@ export namespace CheckboxGroupT {
     /**
      * Group container that owns checkbox collection state and layout.
      */
-
     root?: T
 
     /** Fieldset element that groups checkbox options for accessibility. */

--- a/src/forms/checkbox-group/checkbox-group.tsx
+++ b/src/forms/checkbox-group/checkbox-group.tsx
@@ -26,7 +26,6 @@ export namespace CheckboxGroupT {
   export interface Slot<T = unknown> {
     /**
      * Group container that owns checkbox collection state and layout.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/forms/checkbox-group/checkbox-group.tsx
+++ b/src/forms/checkbox-group/checkbox-group.tsx
@@ -24,7 +24,11 @@ import {
 
 export namespace CheckboxGroupT {
   export interface Slot<T = unknown> {
-    /** Group container that owns checkbox collection state and layout. */
+    /**
+     * Group container that owns checkbox collection state and layout.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Fieldset element that groups checkbox options for accessibility. */

--- a/src/forms/checkbox/checkbox.tsx
+++ b/src/forms/checkbox/checkbox.tsx
@@ -378,7 +378,7 @@ export function Checkbox<TTrue = boolean, TFalse = boolean>(
       id={`${field.id()}-root`}
       role="group"
       data-slot="root"
-      style={merged.styles?.root}
+      style={{ ...merged.styles?.root, ...merged.style }}
       class={checkboxRootVariants(
         {
           variant: merged.variant,
@@ -390,6 +390,7 @@ export function Checkbox<TTrue = boolean, TFalse = boolean>(
           }),
         merged.variant === 'card' && 'cursor-pointer',
         merged.classes?.root,
+        merged.class,
       )}
       onPointerDown={onRootPointerDown}
       {...dataAttrs()}

--- a/src/forms/checkbox/checkbox.tsx
+++ b/src/forms/checkbox/checkbox.tsx
@@ -32,7 +32,6 @@ export namespace CheckboxT {
     /**
      * Labelable checkbox wrapper that coordinates input, indicator, and text content.
      */
-
     root?: T
 
     /** Text column that groups label and description. */

--- a/src/forms/checkbox/checkbox.tsx
+++ b/src/forms/checkbox/checkbox.tsx
@@ -31,7 +31,6 @@ export namespace CheckboxT {
   export interface Slot<T = unknown> {
     /**
      * Labelable checkbox wrapper that coordinates input, indicator, and text content.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/forms/checkbox/checkbox.tsx
+++ b/src/forms/checkbox/checkbox.tsx
@@ -29,7 +29,11 @@ import {
 
 export namespace CheckboxT {
   export interface Slot<T = unknown> {
-    /** Labelable checkbox wrapper that coordinates input, indicator, and text content. */
+    /**
+     * Labelable checkbox wrapper that coordinates input, indicator, and text content.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Text column that groups label and description. */

--- a/src/forms/file-upload/file-upload.tsx
+++ b/src/forms/file-upload/file-upload.tsx
@@ -48,7 +48,11 @@ export namespace FileUploadT {
   export type Value = File | File[] | null
 
   export interface Slot<T = unknown> {
-    /** Upload component container that owns dropzone, file input, and file list. */
+    /**
+     * Upload component container that owns dropzone, file input, and file list.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Dropzone and picker control users interact with to select files. */

--- a/src/forms/file-upload/file-upload.tsx
+++ b/src/forms/file-upload/file-upload.tsx
@@ -50,7 +50,6 @@ export namespace FileUploadT {
   export interface Slot<T = unknown> {
     /**
      * Upload component container that owns dropzone, file input, and file list.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/forms/file-upload/file-upload.tsx
+++ b/src/forms/file-upload/file-upload.tsx
@@ -691,7 +691,7 @@ export function FileUpload(props: FileUploadProps): JSX.Element {
       role="group"
       disabled={field.disabled()}
       data-slot="root"
-      style={merged.styles?.root}
+      style={{ ...merged.styles?.root, ...merged.style }}
       data-disabled={field.disabled() ? '' : undefined}
       data-readonly={readOnly() ? '' : undefined}
       class={fileUploadRootVariants(
@@ -699,6 +699,7 @@ export function FileUpload(props: FileUploadProps): JSX.Element {
           size: field.size(),
         },
         merged.classes?.root,
+        merged.class,
       )}
     >
       <Show

--- a/src/forms/file-upload/file-upload.tsx
+++ b/src/forms/file-upload/file-upload.tsx
@@ -51,7 +51,6 @@ export namespace FileUploadT {
     /**
      * Upload component container that owns dropzone, file input, and file list.
      */
-
     root?: T
 
     /** Dropzone and picker control users interact with to select files. */

--- a/src/forms/form-field/form-field.tsx
+++ b/src/forms/form-field/form-field.tsx
@@ -39,7 +39,6 @@ export namespace FormFieldT {
   export interface Slot<T = unknown> {
     /**
      * Field wrapper that links label, control, description, and messages.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/forms/form-field/form-field.tsx
+++ b/src/forms/form-field/form-field.tsx
@@ -40,7 +40,6 @@ export namespace FormFieldT {
     /**
      * Field wrapper that links label, control, description, and messages.
      */
-
     root?: T
 
     /** Inner wrapper that arranges label, control, helper text, and messages. */

--- a/src/forms/form-field/form-field.tsx
+++ b/src/forms/form-field/form-field.tsx
@@ -37,7 +37,11 @@ export namespace FormFieldT {
   }
 
   export interface Slot<T = unknown> {
-    /** Field wrapper that links label, control, description, and messages. */
+    /**
+     * Field wrapper that links label, control, description, and messages.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Inner wrapper that arranges label, control, helper text, and messages. */

--- a/src/forms/form-field/form-field.tsx
+++ b/src/forms/form-field/form-field.tsx
@@ -179,6 +179,9 @@ export function FormField(props: FormFieldProps): JSX.Element {
     'orientation',
     'size',
     'classes',
+    'styles',
+    'class',
+    'style',
   ])
 
   const formContext = useFormContext()
@@ -331,7 +334,7 @@ export function FormField(props: FormFieldProps): JSX.Element {
       <Dynamic
         component={local.as}
         data-slot="root"
-        style={merged.styles?.root}
+        style={{ ...merged.styles?.root, ...merged.style }}
         data-orientation={local.orientation}
         class={formFieldSizeVariants(
           {
@@ -339,6 +342,7 @@ export function FormField(props: FormFieldProps): JSX.Element {
           },
           local.orientation === 'horizontal' && 'flex items-baseline justify-between gap-2',
           local.classes?.root,
+          local.class,
         )}
         {...rest}
       >

--- a/src/forms/form/form.tsx
+++ b/src/forms/form/form.tsx
@@ -310,6 +310,8 @@ export function Form<TState extends object = object>(props: FormProps<TState>): 
     'onError',
     'classes',
     'styles',
+    'class',
+    'style',
     'children',
   ])
 
@@ -668,8 +670,8 @@ export function Form<TState extends object = object>(props: FormProps<TState>): 
     <FormProvider value={contextValue}>
       <form
         id={formId()}
-        style={local.styles?.root}
-        class={cn('w-full data-loading:opacity-80', local.classes?.root)}
+        style={{ ...local.styles?.root, ...local.style }}
+        class={cn('w-full data-loading:opacity-80', local.classes?.root, local.class)}
         data-loading={formState.loading ? '' : undefined}
         onSubmit={onSubmit}
         {...rest}

--- a/src/forms/form/form.tsx
+++ b/src/forms/form/form.tsx
@@ -56,7 +56,6 @@ export namespace FormT {
   export interface Slot<T = unknown> {
     /**
      * Form element that owns validation, submission, and field context.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/forms/form/form.tsx
+++ b/src/forms/form/form.tsx
@@ -57,7 +57,6 @@ export namespace FormT {
     /**
      * Form element that owns validation, submission, and field context.
      */
-
     root?: T
   }
 

--- a/src/forms/form/form.tsx
+++ b/src/forms/form/form.tsx
@@ -54,7 +54,11 @@ export namespace FormT {
   }
 
   export interface Slot<T = unknown> {
-    /** Form element that owns validation, submission, and field context. */
+    /**
+     * Form element that owns validation, submission, and field context.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
   }
 

--- a/src/forms/input-number/input-number.tsx
+++ b/src/forms/input-number/input-number.tsx
@@ -831,13 +831,14 @@ export function InputNumber(props: InputNumberProps): JSX.Element {
       id={`${field.id()}-root`}
       role="group"
       data-slot="root"
-      style={merged.styles?.root}
+      style={{ ...merged.styles?.root, ...merged.style }}
       class={inputNumberRootVariants(
         {
           size: field.size(),
           variant: merged.variant,
         },
         merged.classes?.root,
+        merged.class,
       )}
       {...dataAttrs()}
     >

--- a/src/forms/input-number/input-number.tsx
+++ b/src/forms/input-number/input-number.tsx
@@ -150,7 +150,6 @@ export namespace InputNumberT {
     /**
      * Number input wrapper that owns the input and step controls.
      */
-
     root?: T
 
     /** Native number input element. */

--- a/src/forms/input-number/input-number.tsx
+++ b/src/forms/input-number/input-number.tsx
@@ -149,7 +149,6 @@ export namespace InputNumberT {
   export interface Slot<T = unknown> {
     /**
      * Number input wrapper that owns the input and step controls.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/forms/input-number/input-number.tsx
+++ b/src/forms/input-number/input-number.tsx
@@ -147,7 +147,11 @@ function clamp(value: number, min: number, max: number): number {
 
 export namespace InputNumberT {
   export interface Slot<T = unknown> {
-    /** Number input wrapper that owns the input and step controls. */
+    /**
+     * Number input wrapper that owns the input and step controls.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Native number input element. */

--- a/src/forms/input/input.tsx
+++ b/src/forms/input/input.tsx
@@ -30,7 +30,6 @@ export namespace InputT {
   export interface Slot<T = unknown> {
     /**
      * Input wrapper that positions icons, loading state, and the native input.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/forms/input/input.tsx
+++ b/src/forms/input/input.tsx
@@ -28,7 +28,11 @@ export namespace InputT {
   export type Value = string | number | undefined
 
   export interface Slot<T = unknown> {
-    /** Input wrapper that positions icons, loading state, and the native input. */
+    /**
+     * Input wrapper that positions icons, loading state, and the native input.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Native text input element. */

--- a/src/forms/input/input.tsx
+++ b/src/forms/input/input.tsx
@@ -318,13 +318,14 @@ export function Input<M extends ModelModifiers | undefined = ModelModifiers | un
   return (
     <div
       data-slot="root"
-      style={merged.styles?.root}
+      style={{ ...merged.styles?.root, ...merged.style }}
       class={inputRootVariants(
         {
           size: field.size(),
           variant: merged.variant,
         },
         merged.classes?.root,
+        merged.class,
       )}
       onPointerDown={onRootPointerDown}
       {...dataAttrs()}

--- a/src/forms/input/input.tsx
+++ b/src/forms/input/input.tsx
@@ -31,7 +31,6 @@ export namespace InputT {
     /**
      * Input wrapper that positions icons, loading state, and the native input.
      */
-
     root?: T
 
     /** Native text input element. */

--- a/src/forms/radio-group/radio-group.tsx
+++ b/src/forms/radio-group/radio-group.tsx
@@ -245,8 +245,8 @@ export function RadioGroup(props: RadioGroupProps): JSX.Element {
       aria-disabled={field.disabled() || undefined}
       aria-readonly={readOnly() || undefined}
       data-slot="root"
-      style={merged.styles?.root}
-      class={cn('relative', merged.classes?.root)}
+      style={{ ...merged.styles?.root, ...merged.style }}
+      class={cn('relative', merged.classes?.root, merged.class)}
       {...dataAttrs()}
       {...field.ariaAttrs()}
     >

--- a/src/forms/radio-group/radio-group.tsx
+++ b/src/forms/radio-group/radio-group.tsx
@@ -28,7 +28,11 @@ import {
 
 export namespace RadioGroupT {
   export interface Slot<T = unknown> {
-    /** Radio group container that owns selection state and layout. */
+    /**
+     * Radio group container that owns selection state and layout.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Fieldset element that groups radio options for accessibility. */

--- a/src/forms/radio-group/radio-group.tsx
+++ b/src/forms/radio-group/radio-group.tsx
@@ -31,7 +31,6 @@ export namespace RadioGroupT {
     /**
      * Radio group container that owns selection state and layout.
      */
-
     root?: T
 
     /** Fieldset element that groups radio options for accessibility. */

--- a/src/forms/radio-group/radio-group.tsx
+++ b/src/forms/radio-group/radio-group.tsx
@@ -30,7 +30,6 @@ export namespace RadioGroupT {
   export interface Slot<T = unknown> {
     /**
      * Radio group container that owns selection state and layout.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/forms/select/base-select.tsx
+++ b/src/forms/select/base-select.tsx
@@ -83,7 +83,6 @@ export namespace BaseSelectT {
   export interface Slot<T = unknown> {
     /**
      * Select root that owns open state, value display, and popup positioning.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/forms/select/base-select.tsx
+++ b/src/forms/select/base-select.tsx
@@ -84,7 +84,6 @@ export namespace BaseSelectT {
     /**
      * Select root that owns open state, value display, and popup positioning.
      */
-
     root?: T
 
     /** Popup panel that contains search input, options, groups, and empty state. */

--- a/src/forms/select/base-select.tsx
+++ b/src/forms/select/base-select.tsx
@@ -818,8 +818,8 @@ export function BaseSelect<TItem extends BaseSelectT.Item>(
       data-disabled={field.disabled() ? '' : undefined}
       data-invalid={field.invalid() ? '' : undefined}
       data-required={merged.required ? '' : undefined}
-      style={merged.styles?.root}
-      class={cn('inline-flex h-fit w-full relative', merged.classes?.root)}
+      style={{ ...merged.styles?.root, ...merged.style }}
+      class={cn('inline-flex h-fit w-full relative', merged.classes?.root, merged.class)}
     >
       {props.children({
         ...stateApi,

--- a/src/forms/select/base-select.tsx
+++ b/src/forms/select/base-select.tsx
@@ -81,7 +81,11 @@ export namespace BaseSelectT {
   }
 
   export interface Slot<T = unknown> {
-    /** Select root that owns open state, value display, and popup positioning. */
+    /**
+     * Select root that owns open state, value display, and popup positioning.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Popup panel that contains search input, options, groups, and empty state. */

--- a/src/forms/select/multi-select.tsx
+++ b/src/forms/select/multi-select.tsx
@@ -608,9 +608,9 @@ export function MultiSelect<TItem extends MultiSelectT.Value = MultiSelectT.Valu
                         size={api.field.size()}
                         title={option.key}
                         variant={props.tagVariant}
-                        styles={{ root: props.styles?.tag }}
+                        style={props.styles?.tag}
+                        class={cn('pe-0 max-w-50%', props.classes?.tag)}
                         classes={{
-                          root: ['max-w-50% pe-0', props.classes?.tag],
                           trailing: ['rounded hover:bg-accent scale-85', props.classes?.tagRemove],
                         }}
                         trailing={props.closeIcon ?? 'icon-close'}

--- a/src/forms/slider/slider.test.tsx
+++ b/src/forms/slider/slider.test.tsx
@@ -815,9 +815,8 @@ describe('Slider', () => {
 
     expect(dividers).toHaveLength(4)
     expect((dividers[0] as HTMLElement).style.left).toBe('20%')
-    expect(dividers[0]?.className).toContain('h-1/2')
+    expect(dividers[0]?.className).toContain('h-full')
     expect(dividers[0]?.className).toContain('w-px')
-    expect(dividers[0]?.className).toContain('z-0')
   })
 
   test('uses a solid track and inset marker shape for bold variant', () => {
@@ -829,16 +828,14 @@ describe('Slider', () => {
     const thumb = screen.container.querySelector('[data-slot="thumb"]')
 
     expect(track?.className).toContain('var-slider-18')
-    expect(track?.className).toContain('before:(inset-0 rounded)')
     expect(range?.className).toContain('rounded')
-    expect(range?.className).toContain('z-10')
+    expect(range?.className).toContain('z-2')
     expect(divider?.className).toContain('w-px')
-    expect(divider?.className).toContain('z-0')
     expect(divider?.className).not.toContain('opacity-0')
     expect(thumb?.className).toContain('bg-primary-foreground')
-    expect(thumb?.className).toContain('z-20')
+    expect(thumb?.className).toContain('z-3')
     expect(thumb?.className).not.toContain('cursor-pointer')
-    expect(thumb?.className).toContain('focus-visible:outline-primary-foreground')
+    expect(thumb?.className).toContain('focus-visible:outline-(1 border primary-foreground)')
     expect(thumb?.className).toContain('rounded-sm')
     expect(thumb?.className).toContain('h-3')
     expect(thumb?.className).toContain('w-1')
@@ -864,7 +861,7 @@ describe('Slider', () => {
     thumb.focus()
 
     expect(document.activeElement).toBe(thumb)
-    expect(thumb.className).toContain('focus-visible:outline-primary-foreground')
+    expect(thumb.className).toContain('focus-visible:outline-(1 border primary-foreground)')
 
     await fireEvent.pointerDown(thumb, {
       button: 0,

--- a/src/forms/slider/slider.tsx
+++ b/src/forms/slider/slider.tsx
@@ -40,7 +40,6 @@ export namespace SliderT {
     /**
      * Slider container that owns track, range, thumbs, and labels.
      */
-
     root?: T
 
     /** Background rail representing the full slider range. */

--- a/src/forms/slider/slider.tsx
+++ b/src/forms/slider/slider.tsx
@@ -37,7 +37,11 @@ export namespace SliderT {
   export type Value = number | number[]
 
   export interface Slot<T = unknown> {
-    /** Slider container that owns track, range, thumbs, and labels. */
+    /**
+     * Slider container that owns track, range, thumbs, and labels.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Background rail representing the full slider range. */

--- a/src/forms/slider/slider.tsx
+++ b/src/forms/slider/slider.tsx
@@ -672,11 +672,12 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
       data-invalid={field.invalid() ? '' : undefined}
       data-readonly={merged.readOnly ? '' : undefined}
       data-required={merged.required ? '' : undefined}
-      style={merged.styles?.root}
+      style={{ ...merged.styles?.root, ...merged.style }}
       class={sliderRootVariants(
         { orientation: merged.orientation },
         field.disabled() && 'effect-dis',
         merged.classes?.root,
+        merged.class,
       )}
     >
       <div

--- a/src/forms/slider/slider.tsx
+++ b/src/forms/slider/slider.tsx
@@ -39,7 +39,6 @@ export namespace SliderT {
   export interface Slot<T = unknown> {
     /**
      * Slider container that owns track, range, thumbs, and labels.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/forms/switch/switch.tsx
+++ b/src/forms/switch/switch.tsx
@@ -21,7 +21,11 @@ import { switchTrackVariants, switchThumbVariants, switchWrapperVariants } from 
 
 export namespace SwitchT {
   export interface Slot<T = unknown> {
-    /** Switch wrapper that coordinates input, track, thumb, and text content. */
+    /**
+     * Switch wrapper that coordinates input, track, thumb, and text content.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Visible switch track that shows checked and unchecked state. */

--- a/src/forms/switch/switch.tsx
+++ b/src/forms/switch/switch.tsx
@@ -24,7 +24,6 @@ export namespace SwitchT {
     /**
      * Switch wrapper that coordinates input, track, thumb, and text content.
      */
-
     root?: T
 
     /** Visible switch track that shows checked and unchecked state. */

--- a/src/forms/switch/switch.tsx
+++ b/src/forms/switch/switch.tsx
@@ -23,7 +23,6 @@ export namespace SwitchT {
   export interface Slot<T = unknown> {
     /**
      * Switch wrapper that coordinates input, track, thumb, and text content.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/forms/switch/switch.tsx
+++ b/src/forms/switch/switch.tsx
@@ -315,8 +315,8 @@ export function Switch<TTrue = boolean, TFalse = boolean>(
   return (
     <div
       data-slot="root"
-      style={merged.styles?.root}
-      class={cn('flex flex-row', merged.classes?.root)}
+      style={{ ...merged.styles?.root, ...merged.style }}
+      class={cn('flex flex-row', merged.classes?.root, merged.class)}
     >
       <HiddenInput
         ref={(element) => {

--- a/src/forms/textarea/textarea.tsx
+++ b/src/forms/textarea/textarea.tsx
@@ -44,7 +44,6 @@ export namespace TextareaT {
   export interface Slot<T = unknown> {
     /**
      * Textarea wrapper that owns header, textarea, footer, and autoresize state.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/forms/textarea/textarea.tsx
+++ b/src/forms/textarea/textarea.tsx
@@ -45,7 +45,6 @@ export namespace TextareaT {
     /**
      * Textarea wrapper that owns header, textarea, footer, and autoresize state.
      */
-
     root?: T
 
     /** Optional content rendered above the textarea. */

--- a/src/forms/textarea/textarea.tsx
+++ b/src/forms/textarea/textarea.tsx
@@ -340,13 +340,14 @@ export function Textarea<M extends ModelModifiers | undefined = ModelModifiers |
   return (
     <div
       data-slot="root"
-      style={merged.styles?.root}
+      style={{ ...merged.styles?.root, ...merged.style }}
       class={textareaRootVariants(
         {
           size: field.size(),
           variant: merged.variant,
         },
         merged.classes?.root,
+        merged.class,
       )}
       onPointerDown={onRootPointerDown}
       {...dataAttrs()}

--- a/src/forms/textarea/textarea.tsx
+++ b/src/forms/textarea/textarea.tsx
@@ -42,7 +42,11 @@ export namespace TextareaT {
   export type Value = string | number | undefined
 
   export interface Slot<T = unknown> {
-    /** Textarea wrapper that owns header, textarea, footer, and autoresize state. */
+    /**
+     * Textarea wrapper that owns header, textarea, footer, and autoresize state.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Optional content rendered above the textarea. */

--- a/src/navigation/breadcrumb/breadcrumb.tsx
+++ b/src/navigation/breadcrumb/breadcrumb.tsx
@@ -39,7 +39,6 @@ export namespace BreadcrumbT {
   export interface Slot<T = unknown> {
     /**
      * Navigation container for the breadcrumb trail.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/navigation/breadcrumb/breadcrumb.tsx
+++ b/src/navigation/breadcrumb/breadcrumb.tsx
@@ -37,7 +37,11 @@ export namespace BreadcrumbT {
   }
 
   export interface Slot<T = unknown> {
-    /** Navigation container for the breadcrumb trail. */
+    /**
+     * Navigation container for the breadcrumb trail.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Ordered list that contains breadcrumb items and separators. */
@@ -227,8 +231,8 @@ export function Breadcrumb(props: BreadcrumbProps): JSX.Element {
                     disabled={isDisabled()}
                     onClick={item.onClick}
                     leading={item.icon}
+                    class={cn(!merged.wrap && 'truncate', merged.classes?.link)}
                     classes={{
-                      root: [!merged.wrap && 'truncate', merged.classes?.link],
                       leading: merged.classes?.leading,
                       label: merged.classes?.label,
                     }}

--- a/src/navigation/breadcrumb/breadcrumb.tsx
+++ b/src/navigation/breadcrumb/breadcrumb.tsx
@@ -40,7 +40,6 @@ export namespace BreadcrumbT {
     /**
      * Navigation container for the breadcrumb trail.
      */
-
     root?: T
 
     /** Ordered list that contains breadcrumb items and separators. */

--- a/src/navigation/breadcrumb/breadcrumb.tsx
+++ b/src/navigation/breadcrumb/breadcrumb.tsx
@@ -174,9 +174,9 @@ export function Breadcrumb(props: BreadcrumbProps): JSX.Element {
   return (
     <nav
       data-slot="root"
-      style={merged.styles?.root}
+      style={{ ...merged.styles?.root, ...merged.style }}
       aria-label={merged['aria-label']}
-      class={cn('min-w-0 relative', merged.classes?.root)}
+      class={cn('min-w-0 relative', merged.classes?.root, merged.class)}
     >
       <ol
         data-slot="list"

--- a/src/navigation/command-palette/command-palette.tsx
+++ b/src/navigation/command-palette/command-palette.tsx
@@ -44,7 +44,11 @@ export namespace CommandPaletteT {
   }
 
   export interface Slot<T = unknown> {
-    /** Command palette container that owns search, navigation stack, and option list. */
+    /**
+     * Command palette container that owns search, navigation stack, and option list.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Search row that groups input, search icon, and navigation controls. */
@@ -485,29 +489,25 @@ export function CommandPalette(props: CommandPaletteProps): JSX.Element {
               name={merged.loading ? (merged.loadingIcon ?? 'icon-loading') : merged.searchIcon}
               data-slot="search"
               tabIndex={-1}
-              styles={{ root: merged.styles?.search }}
+              style={merged.styles?.search}
               aria-busy={merged.loading || undefined}
               data-loading={merged.loading ? '' : undefined}
               disabled={merged.loading || undefined}
-              classes={{
-                root: ['text-muted-foreground size-5 pointer-events-none', merged.classes?.search],
-              }}
+              class={cn('text-muted-foreground size-5 pointer-events-none', merged.classes?.search)}
             />
           }
         >
           <IconButtonInner
             name={merged.loading ? (merged.loadingIcon ?? 'icon-loading') : merged.backIcon}
             data-slot="back"
-            styles={{ root: merged.styles?.back }}
+            style={merged.styles?.back}
             aria-busy={merged.loading || undefined}
             data-loading={merged.loading ? '' : undefined}
             disabled={merged.loading || undefined}
-            classes={{
-              root: [
-                'text-muted-foreground outline-none hover:text-foreground',
-                merged.classes?.back,
-              ],
-            }}
+            class={cn(
+              'text-muted-foreground outline-none hover:text-foreground',
+              merged.classes?.back,
+            )}
             onClick={navigateBack}
             aria-label="Go back"
           />
@@ -535,13 +535,11 @@ export function CommandPalette(props: CommandPaletteProps): JSX.Element {
           <IconButtonInner
             name={merged.closeIcon}
             data-slot="close"
-            styles={{ root: merged.styles?.close }}
-            classes={{
-              root: [
-                'text-muted-foreground outline-none shrink-0 cursor-pointer hover:text-foreground',
-                merged.classes?.close,
-              ],
-            }}
+            style={merged.styles?.close}
+            class={cn(
+              'text-muted-foreground outline-none shrink-0 cursor-pointer hover:text-foreground',
+              merged.classes?.close,
+            )}
             onClick={() => merged.onClose?.()}
             aria-label="Close"
           />

--- a/src/navigation/command-palette/command-palette.tsx
+++ b/src/navigation/command-palette/command-palette.tsx
@@ -466,10 +466,11 @@ export function CommandPalette(props: CommandPaletteProps): JSX.Element {
   return (
     <div
       data-slot="root"
-      style={merged.styles?.root}
+      style={{ ...merged.styles?.root, ...merged.style }}
       class={cn(
         'rounded-xl bg-background flex flex-col min-h-0 divide-(border y)',
         merged.classes?.root,
+        merged.class,
       )}
     >
       <div

--- a/src/navigation/command-palette/command-palette.tsx
+++ b/src/navigation/command-palette/command-palette.tsx
@@ -47,7 +47,6 @@ export namespace CommandPaletteT {
     /**
      * Command palette container that owns search, navigation stack, and option list.
      */
-
     root?: T
 
     /** Search row that groups input, search icon, and navigation controls. */

--- a/src/navigation/command-palette/command-palette.tsx
+++ b/src/navigation/command-palette/command-palette.tsx
@@ -46,7 +46,6 @@ export namespace CommandPaletteT {
   export interface Slot<T = unknown> {
     /**
      * Command palette container that owns search, navigation stack, and option list.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/navigation/pagination/pagination.tsx
+++ b/src/navigation/pagination/pagination.tsx
@@ -16,7 +16,6 @@ export namespace PaginationT {
     /**
      * Navigation container for page controls.
      */
-
     root?: T
 
     /** Wrapper that lays out page, ellipsis, previous, and next controls. */

--- a/src/navigation/pagination/pagination.tsx
+++ b/src/navigation/pagination/pagination.tsx
@@ -13,7 +13,11 @@ type PaginationVariant = ButtonProps['variant']
 
 export namespace PaginationT {
   export interface Slot<T = unknown> {
-    /** Navigation container for page controls. */
+    /**
+     * Navigation container for page controls.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Wrapper that lays out page, ellipsis, previous, and next controls. */
@@ -346,7 +350,7 @@ export function Pagination(props: PaginationProps): JSX.Element {
               variant={local.controlVariant}
               size={getSize(local.size, local.prevText)}
               aria-label={getPrevLabel()}
-              classes={{ root: local.classes?.prev }}
+              class={local.classes?.prev}
               onClick={() => selectPage(resolvedPage() - 1)}
               {...getControlProps(resolvedPage() - 1, resolvedPage() <= 1, 'prev')}
               leading={<Icon name={local.prevIcon} />}
@@ -385,7 +389,7 @@ export function Pagination(props: PaginationProps): JSX.Element {
                     aria-current={isActive() ? 'page' : undefined}
                     aria-label={getPageLabel(item, isActive())}
                     data-current={isActive() ? '' : undefined}
-                    classes={{ root: ['outline-none', local.classes?.link] }}
+                    class={cn('outline-none', local.classes?.link)}
                     onClick={() => selectPage(item)}
                     {...getControlProps(item, false)}
                   >
@@ -405,7 +409,7 @@ export function Pagination(props: PaginationProps): JSX.Element {
               variant={local.controlVariant}
               size={getSize(local.size, local.nextText)}
               aria-label={getNextLabel()}
-              classes={{ root: local.classes?.next }}
+              class={local.classes?.next}
               onClick={() => selectPage(resolvedPage() + 1)}
               {...getControlProps(resolvedPage() + 1, resolvedPage() >= pageCount(), 'next')}
               trailing={<Icon name={local.nextIcon} />}

--- a/src/navigation/pagination/pagination.tsx
+++ b/src/navigation/pagination/pagination.tsx
@@ -228,6 +228,8 @@ export function Pagination(props: PaginationProps): JSX.Element {
     'controlVariant',
     'classes',
     'styles',
+    'class',
+    'style',
     'prevIcon',
     'prevText',
     'nextIcon',
@@ -327,8 +329,8 @@ export function Pagination(props: PaginationProps): JSX.Element {
   return (
     <nav
       data-slot="root"
-      style={local.styles?.root}
-      class={cn('w-full', local.classes?.root)}
+      style={{ ...local.styles?.root, ...local.style }}
+      class={cn('w-full', local.classes?.root, local.class)}
       {...rest}
     >
       <ul

--- a/src/navigation/pagination/pagination.tsx
+++ b/src/navigation/pagination/pagination.tsx
@@ -15,7 +15,6 @@ export namespace PaginationT {
   export interface Slot<T = unknown> {
     /**
      * Navigation container for page controls.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/navigation/sidebar-frame/sidebar-frame.tsx
+++ b/src/navigation/sidebar-frame/sidebar-frame.tsx
@@ -70,7 +70,6 @@ export namespace SidebarFrameT {
   export interface Slot<T = unknown> {
     /**
      * Frame container that coordinates sidebar and main content layout.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/navigation/sidebar-frame/sidebar-frame.tsx
+++ b/src/navigation/sidebar-frame/sidebar-frame.tsx
@@ -68,7 +68,11 @@ export namespace SidebarFrameT {
    * Slot keys for classes/styles overrides.
    */
   export interface Slot<T = unknown> {
-    /** Frame container that coordinates sidebar and main content layout. */
+    /**
+     * Frame container that coordinates sidebar and main content layout.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Sidebar region rendered inline on desktop or inside a sheet on mobile. */

--- a/src/navigation/sidebar-frame/sidebar-frame.tsx
+++ b/src/navigation/sidebar-frame/sidebar-frame.tsx
@@ -71,7 +71,6 @@ export namespace SidebarFrameT {
     /**
      * Frame container that coordinates sidebar and main content layout.
      */
-
     root?: T
 
     /** Sidebar region rendered inline on desktop or inside a sheet on mobile. */

--- a/src/navigation/sidebar-frame/sidebar-frame.tsx
+++ b/src/navigation/sidebar-frame/sidebar-frame.tsx
@@ -298,8 +298,8 @@ export function SidebarFrame(props: SidebarFrameProps): JSX.Element {
   return (
     <div
       data-slot="root"
-      style={merged.styles?.root}
-      class={cn('h-screen max-h-full min-h-0 overflow-hidden', merged.classes?.root)}
+      style={{ ...merged.styles?.root, ...merged.style }}
+      class={cn('h-screen max-h-full min-h-0 overflow-hidden', merged.classes?.root, merged.class)}
     >
       <merged.renderFrame
         {...context}

--- a/src/navigation/stepper/stepper.tsx
+++ b/src/navigation/stepper/stepper.tsx
@@ -311,8 +311,12 @@ export function Stepper(props: StepperProps): JSX.Element {
     <div
       id={id()}
       data-slot="root"
-      style={merged.styles?.root}
-      class={stepperRootVariants({ orientation: merged.orientation }, merged.classes?.root)}
+      style={{ ...merged.styles?.root, ...merged.style }}
+      class={stepperRootVariants(
+        { orientation: merged.orientation },
+        merged.classes?.root,
+        merged.class,
+      )}
     >
       <div
         role="tablist"

--- a/src/navigation/stepper/stepper.tsx
+++ b/src/navigation/stepper/stepper.tsx
@@ -27,7 +27,11 @@ export namespace StepperT {
   export type Value = string
 
   export interface Slot<T = unknown> {
-    /** Stepper container that owns orientation, step state, and panel rendering. */
+    /**
+     * Stepper container that owns orientation, step state, and panel rendering.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Step navigation header that contains all step triggers. */

--- a/src/navigation/stepper/stepper.tsx
+++ b/src/navigation/stepper/stepper.tsx
@@ -30,7 +30,6 @@ export namespace StepperT {
     /**
      * Stepper container that owns orientation, step state, and panel rendering.
      */
-
     root?: T
 
     /** Step navigation header that contains all step triggers. */

--- a/src/navigation/stepper/stepper.tsx
+++ b/src/navigation/stepper/stepper.tsx
@@ -29,7 +29,6 @@ export namespace StepperT {
   export interface Slot<T = unknown> {
     /**
      * Stepper container that owns orientation, step state, and panel rendering.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/navigation/tabs/tabs.tsx
+++ b/src/navigation/tabs/tabs.tsx
@@ -342,8 +342,12 @@ export function Tabs(props: TabsProps): JSX.Element {
       id={rootId()}
       data-slot="root"
       data-orientation={merged.orientation}
-      style={merged.styles?.root}
-      class={tabsRootVariants({ orientation: merged.orientation }, merged.classes?.root)}
+      style={{ ...merged.styles?.root, ...merged.style }}
+      class={tabsRootVariants(
+        { orientation: merged.orientation },
+        merged.classes?.root,
+        merged.class,
+      )}
     >
       <div
         ref={(e) => (listRef = e)}

--- a/src/navigation/tabs/tabs.tsx
+++ b/src/navigation/tabs/tabs.tsx
@@ -31,7 +31,6 @@ export namespace TabsT {
   export interface Slot<T = unknown> {
     /**
      * Tabs container that owns tab selection and panel rendering.
-     * @deprecated Use top-level `class` and `style` props for the component root.
      */
 
     root?: T

--- a/src/navigation/tabs/tabs.tsx
+++ b/src/navigation/tabs/tabs.tsx
@@ -32,7 +32,6 @@ export namespace TabsT {
     /**
      * Tabs container that owns tab selection and panel rendering.
      */
-
     root?: T
 
     /** Tablist that contains all tab triggers and the selection indicator. */

--- a/src/navigation/tabs/tabs.tsx
+++ b/src/navigation/tabs/tabs.tsx
@@ -29,7 +29,11 @@ import type { TabsVariantProps } from './tabs.class'
 
 export namespace TabsT {
   export interface Slot<T = unknown> {
-    /** Tabs container that owns tab selection and panel rendering. */
+    /**
+     * Tabs container that owns tab selection and panel rendering.
+     * @deprecated Use top-level `class` and `style` props for the component root.
+     */
+
     root?: T
 
     /** Tablist that contains all tab triggers and the selection indicator. */

--- a/src/overlays/context-menu/context-menu.tsx
+++ b/src/overlays/context-menu/context-menu.tsx
@@ -330,8 +330,8 @@ export function ContextMenu(props: ContextMenuProps): JSX.Element {
         aria-haspopup="menu"
         aria-controls={resolvedOpen() ? contentId() : undefined}
         aria-expanded={resolvedOpen() ? 'true' : 'false'}
-        class={cn(merged.classes?.trigger)}
-        style={{ '-webkit-touch-callout': 'none', ...merged.styles?.trigger }}
+        class={cn(merged.classes?.trigger, merged.class)}
+        style={{ '-webkit-touch-callout': 'none', ...merged.styles?.trigger, ...merged.style }}
         onContextMenu={onContextMenu}
         onPointerDown={onPointerDown}
         onPointerMove={onPointerMove}

--- a/src/overlays/dialog/dialog.tsx
+++ b/src/overlays/dialog/dialog.tsx
@@ -242,7 +242,7 @@ export function Dialog(props: DialogProps): JSX.Element {
       preventScroll={!merged.scrollable}
       trigger={merged.children}
       classes={{
-        trigger: merged.classes?.trigger,
+        trigger: cn(merged.classes?.trigger, merged.class),
         overlay: popupOverlayVariants(
           {
             scrollable: merged.scrollable,
@@ -257,7 +257,7 @@ export function Dialog(props: DialogProps): JSX.Element {
         ),
       }}
       styles={{
-        trigger: merged.styles?.trigger,
+        trigger: { ...merged.styles?.trigger, ...merged.style },
         overlay: merged.styles?.overlay,
         content: merged.styles?.content,
       }}

--- a/src/overlays/dropdown-menu/dropdown-menu.test.tsx
+++ b/src/overlays/dropdown-menu/dropdown-menu.test.tsx
@@ -18,6 +18,19 @@ async function finishMenuExitMotion(): Promise<void> {
 }
 
 describe('DropdownMenu', () => {
+  test('applies top-level class and style to trigger', () => {
+    render(() => (
+      <DropdownMenu items={[{ label: 'Archive' }]} class="trigger-class" style={{ width: '200px' }}>
+        <button type="button">Actions</button>
+      </DropdownMenu>
+    ))
+
+    const trigger = document.body.querySelector('[data-slot="trigger"]') as HTMLElement | null
+
+    expect(trigger?.className).toContain('trigger-class')
+    expect(trigger?.style.width).toBe('200px')
+  })
+
   test('opens by keyboard and supports keyboard selection', async () => {
     const onSelect = vi.fn()
 

--- a/src/overlays/dropdown-menu/dropdown-menu.tsx
+++ b/src/overlays/dropdown-menu/dropdown-menu.tsx
@@ -109,8 +109,8 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
         aria-haspopup="menu"
         aria-controls={isOpen() ? contentId() : undefined}
         aria-expanded={isOpen() ? 'true' : 'false'}
-        style={merged.styles?.trigger}
-        class={cn('outline-none', merged.classes?.trigger)}
+        style={{ ...merged.styles?.trigger, ...merged.style }}
+        class={cn('outline-none', merged.classes?.trigger, merged.class)}
         onClick={(event) => {
           if (event.defaultPrevented || merged.disabled) {
             return

--- a/src/overlays/popover/popover.tsx
+++ b/src/overlays/popover/popover.tsx
@@ -165,8 +165,8 @@ export function Popover(props: PopoverProps): JSX.Element {
       role="dialog"
       toggleOnClick={merged.mode === 'click'}
       trigger={merged.children}
-      triggerStyle={merged.styles?.trigger}
-      triggerClass={cn(merged.classes?.trigger)}
+      triggerStyle={{ ...merged.styles?.trigger, ...merged.style }}
+      triggerClass={cn(merged.classes?.trigger, merged.class)}
       onTriggerPointerEnter={
         merged.mode === 'hover'
           ? ({ open }) => {

--- a/src/overlays/popup/popup.test.tsx
+++ b/src/overlays/popup/popup.test.tsx
@@ -118,6 +118,19 @@ describe('Popup', () => {
     )
   })
 
+  test('applies top-level class and style to trigger', () => {
+    render(() => (
+      <Popup open content="Body" class="trigger-class" style={{ width: '200px' }}>
+        <button type="button">Trigger</button>
+      </Popup>
+    ))
+
+    const trigger = document.body.querySelector('[data-slot="trigger"]') as HTMLElement | null
+
+    expect(trigger?.className).toContain('trigger-class')
+    expect(trigger?.style.width).toBe('200px')
+  })
+
   test('does not render content when content is undefined or null', () => {
     render(() => (
       <Popup open>

--- a/src/overlays/popup/popup.tsx
+++ b/src/overlays/popup/popup.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'solid-js'
 import { mergeProps } from 'solid-js'
 
 import type { BaseProps, SlotClassValue, SlotStyleValue } from '../../shared/types'
+import { cn } from '../../shared/utils'
 import { Modal } from '../base/modal'
 import type { ModalProps } from '../base/modal'
 
@@ -103,7 +104,7 @@ export function Popup(props: PopupProps): JSX.Element {
       preventScroll={!merged.scrollable}
       trigger={merged.children}
       classes={{
-        trigger: merged.classes?.trigger,
+        trigger: cn(merged.classes?.trigger, merged.class),
         overlay: popupOverlayVariants(
           {
             scrollable: merged.scrollable,
@@ -118,7 +119,7 @@ export function Popup(props: PopupProps): JSX.Element {
         ),
       }}
       styles={{
-        trigger: merged.styles?.trigger,
+        trigger: { ...merged.styles?.trigger, ...merged.style },
         overlay: merged.styles?.overlay,
         content: merged.styles?.content,
       }}

--- a/src/overlays/sheet/sheet.tsx
+++ b/src/overlays/sheet/sheet.tsx
@@ -152,7 +152,7 @@ export function Sheet(props: SheetProps): JSX.Element {
       onClosePrevent={merged.onClosePrevent}
       trigger={merged.children}
       classes={{
-        trigger: merged.classes?.trigger,
+        trigger: cn(merged.classes?.trigger, merged.class),
         overlay: cn(
           'bg-black/10 duration-150 inset-0 fixed z-50 backdrop-blur-xs data-closed:animate-overlay-out data-expanded:animate-overlay-in',
           merged.classes?.overlay,
@@ -168,7 +168,7 @@ export function Sheet(props: SheetProps): JSX.Element {
         ),
       }}
       styles={{
-        trigger: merged.styles?.trigger,
+        trigger: { ...merged.styles?.trigger, ...merged.style },
         overlay: merged.styles?.overlay,
         content: merged.styles?.content,
       }}

--- a/src/overlays/tooltip/tooltip.test.tsx
+++ b/src/overlays/tooltip/tooltip.test.tsx
@@ -44,6 +44,19 @@ describe('Tooltip', () => {
     expect(trigger?.getAttribute('tabindex')).toBe('-1')
   })
 
+  test('applies top-level class and style to trigger', () => {
+    render(() => (
+      <Tooltip text="Tooltip content" class="trigger-class" style={{ width: '200px' }}>
+        <button type="button">Trigger</button>
+      </Tooltip>
+    ))
+
+    const trigger = document.body.querySelector('[data-slot="trigger"]') as HTMLElement | null
+
+    expect(trigger?.className).toContain('trigger-class')
+    expect(trigger?.style.width).toBe('200px')
+  })
+
   test('renders keyboard hints', () => {
     render(() => (
       <Tooltip open text="Save" kbds={['Ctrl', 'S']}>

--- a/src/overlays/tooltip/tooltip.tsx
+++ b/src/overlays/tooltip/tooltip.tsx
@@ -184,8 +184,8 @@ export function Tooltip(props: TooltipProps): JSX.Element {
       toggleOnClick={false}
       describeTrigger
       trigger={merged.children}
-      triggerStyle={merged.styles?.trigger}
-      triggerClass={cn(merged.classes?.trigger)}
+      triggerStyle={{ ...merged.styles?.trigger, ...merged.style }}
+      triggerClass={cn(merged.classes?.trigger, merged.class)}
       onTriggerFocus={({ open }) => {
         scheduleOpen(open)
       }}

--- a/src/overlays/tooltip/tooltip.tsx
+++ b/src/overlays/tooltip/tooltip.tsx
@@ -139,10 +139,8 @@ export function Tooltip(props: TooltipProps): JSX.Element {
           variant={merged.invert ? 'invert' : undefined}
           size="sm"
           value={merged.kbds}
-          classes={{
-            root: [merged.text && 'ms-1', merged.classes?.kbds],
-            item: merged.classes?.kbd,
-          }}
+          class={cn(merged.text && 'ms-1', merged.classes?.kbds)}
+          classes={{ item: merged.classes?.kbd }}
         />
       </div>
     )

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -31,9 +31,9 @@ export type BaseProps<B, V, E, TClasses, TStyles, ExtraOmitKeys extends Property
         | 'styles'
         | Extract<ExtraOmitKeys, keyof E>
       >) & {
-    /** Class applied to the component root element. */
+    /** Class applied to the component root or trigger element. */
     class?: ClassValue
-    /** Style applied to the component root element. */
+    /** Style applied to the component root or trigger element. */
     style?: JSX.CSSProperties
     /** Classes applied to the component slots. */
     classes?: TClasses

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -31,6 +31,10 @@ export type BaseProps<B, V, E, TClasses, TStyles, ExtraOmitKeys extends Property
         | 'styles'
         | Extract<ExtraOmitKeys, keyof E>
       >) & {
+    /** Class applied to the component root element. */
+    class?: ClassValue
+    /** Style applied to the component root element. */
+    style?: JSX.CSSProperties
     classes?: TClasses
     styles?: TStyles
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -35,6 +35,8 @@ export type BaseProps<B, V, E, TClasses, TStyles, ExtraOmitKeys extends Property
     class?: ClassValue
     /** Style applied to the component root element. */
     style?: JSX.CSSProperties
+    /** Classes applied to the component slots. */
     classes?: TClasses
+    /** Styles applied to the component slots. */
     styles?: TStyles
   }

--- a/todo.md
+++ b/todo.md
@@ -6,7 +6,7 @@
   - [x] use dot style in default variant, and use line style in bold variant.
   - [x] change default direction of vertial orientation to bottom -> top
 - [x] refactor switch component's dom structure, make it more semantic and accessible, and remove unnecessary wrapper elements, dont show focus ring when clicked.
-- [ ] unify slot names, only contains inner element slots, the outest slot should be component itself, and add class / style props to component props, so no longer needed to setup classes / styles object for simple root component
+- [x] unify slot names, only contains inner element slots, the outest slot should be component itself, and add class / style props to component props, so no longer needed to setup classes / styles object for simple root component
 - [ ] find a way to add jsdoc for Variant 's props
 - [ ] unify custom render function prop with prefix `render`, target should be `renderXXXX`
 - [ ] reference from https://ink-ui.com , add primary/secondary/background/\*-{active,hover,focus} color tokens, avoid using alpha channel in color tokens

--- a/todo.md
+++ b/todo.md
@@ -7,6 +7,17 @@
   - [x] change default direction of vertial orientation to bottom -> top
 - [x] refactor switch component's dom structure, make it more semantic and accessible, and remove unnecessary wrapper elements, dont show focus ring when clicked.
 - [x] unify slot names, only contains inner element slots, the outest slot should be component itself, and add class / style props to component props, so no longer needed to setup classes / styles object for simple root component
+- [ ] cleanup unncessary `splitProps` and `mergeProps` usage in all components.
+- [ ] rename sperator component 's `container` slot to `content`.
+- [ ] remove unnecessary wrapper memo on `inputAriaAttrs` in `checkbox` component
+- [ ] only add data attributes on essential elements in `checkbox`, unwrap `dataAttr` memo
+- [ ] simplify `avatar` / `checkbox` / `radio-group` 's classes, remove unnecessary wrapper elements, and make it more semantic and accessible.
+- [ ] unify and correct class/style priority: top level `class` / `style` (root only) > `classes` / `styles` > component builtin classes / styles
+- [ ] extract logic from slider component to a separate hook, and all export component level hooks (should located at same dir 's `/hook` dir ) custom implementations.
+- [ ] refactor form / form-field to formisch, replace existing form context logic if possible
+- [ ] add docs for icon-button component.
+- [ ] split `avatar` component into `avatar` and `avatar-group`, and add new `avatar-group` component to group avatars together, and support different sizes and variants.
+- [ ] split `kbd` component into `kbd` and `kbd-group`, and add new `kbd-group` component to group kbd elements together, and support different sizes and variants, customizable divider.
 - [ ] find a way to add jsdoc for Variant 's props
 - [ ] unify custom render function prop with prefix `render`, target should be `renderXXXX`
 - [ ] reference from https://ink-ui.com , add primary/secondary/background/\*-{active,hover,focus} color tokens, avoid using alpha channel in color tokens


### PR DESCRIPTION
### Motivation
- Allow callers to set root-level `class` and `style` directly on components instead of always using `classes.root`/`styles.root` to simplify common customizations and unify slot usage.
- Preserve existing slot-based overrides while making simple root overrides ergonomic for consumers.

### Description
- Add `class?: ClassValue` and `style?: JSX.CSSProperties` to the shared `BaseProps` type in `src/shared/types.ts` to expose root props for all components.
- Wire root merging into representative components by merging `styles?.root` with `style` and merging `classes?.root` with `class`; updated many element, form, and navigation roots (e.g., `Button`, `Badge`, `IconButtonInner`, `Avatar`, `Card`, `Form`, `Input`, `Tabs`, `Pagination`, `Stepper`, `Slider`, `Separator`, `Resizable`, `Checkbox`, `FileUpload`, `Textarea`, and others) to respect the new props while preserving existing slot behavior.
- Update `splitProps` usage in components that accept `class`/`style` so they are passed through correctly to the root element or merged with slot classes/styles.
- Adjusted tests and docs state: updated avatar type-contract test to accept `class` for the root and marked the related item in `todo.md` as completed.

### Testing
- Ran repository QA (`bun run qa`) which performs formatting, linting (`oxlint --fix`) and TypeScript typecheck, and it completed successfully.
- Ran unit tests for Avatar (`bun run test src/elements/avatar/avatar.test.tsx`), and the test file passed (`17 tests passed`).
- Verified that `tsc --noEmit` completed as part of the QA run (typecheck passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45af02de2c83308b7d54d198600ab1)