### PR TITLE
Extract slider logic to `useSlider` hook and wire up pointer cancel handling

### DIFF
--- a/src/forms/slider/hook/index.ts
+++ b/src/forms/slider/hook/index.ts
@@ -1,0 +1,1 @@
+export * from './use-slider'

--- a/src/forms/slider/hook/use-slider.ts
+++ b/src/forms/slider/hook/use-slider.ts
@@ -1,0 +1,569 @@
+import type { JSX } from 'solid-js'
+import { createEffect, createMemo, createSignal, onMount } from 'solid-js'
+
+import { useId } from '../../../shared/utils'
+import { useFormField } from '../../form-field/form-field-context'
+import type { SliderProps, SliderT } from '../slider'
+import {
+  clamp,
+  getClosestValueIndex,
+  getNextSortedValues,
+  hasMinStepsBetweenValues,
+  linearScale,
+  moveSortedValue,
+  normalizeSliderValues,
+  resolveSliderEdges,
+  snapValueToStep,
+} from '../utils'
+
+type UseSliderProps<TValue extends SliderT.Value> = SliderProps<TValue> & {
+  allowThumbCrossing: boolean
+  inverted: boolean
+  max: number
+  min: number
+  minStepsBetweenThumbs: number
+  orientation: 'horizontal' | 'vertical'
+}
+
+export function useSlider<TValue extends SliderT.Value = SliderT.Value>(
+  merged: UseSliderProps<TValue>,
+) {
+  const generatedId = useId(() => merged.id, 'slider')
+  const [displayValues, setDisplayValues] = createSignal<number[]>([])
+  const getControlledValues = () => normalizeSliderValues(merged.value, merged.min!)
+
+  const [dragging, setDragging] = createSignal(false)
+  const definedStep = createMemo(() =>
+    typeof merged.step === 'number' && merged.step > 0 ? merged.step : undefined,
+  )
+  const keyboardStep = createMemo(() => {
+    const range = merged.max! - merged.min!
+    return definedStep() ?? (range > 0 ? range / 100 : 1)
+  })
+  const pageSize = createMemo(() => {
+    let calcPageSize = (merged.max! - merged.min!) / 10
+    const step = definedStep()
+    if (!step) {
+      return calcPageSize
+    }
+
+    calcPageSize = snapValueToStep(calcPageSize, 0, calcPageSize + step, step)
+    return Math.max(calcPageSize, step)
+  })
+  const [thumbRefs, setThumbRefs] = createSignal<Array<HTMLDivElement | undefined>>([])
+  const [trackElement, setTrackElementState] = createSignal<HTMLDivElement | undefined>(undefined)
+  const [activeThumbIndexState, setActiveThumbIndexState] = createSignal<number | undefined>(
+    undefined,
+  )
+  let pendingValues: number[] | undefined
+  let activePointerId: number | undefined
+  let activeThumbIndex: number | undefined
+  let lastUsedThumbIndex: number | undefined
+  let lastPointerPosition = 0
+  let suppressNextBlurCommit = false
+
+  function setActiveThumbIndex(index: number | undefined): void {
+    activeThumbIndex = index
+    if (index !== undefined) {
+      lastUsedThumbIndex = index
+    }
+    setActiveThumbIndexState(index)
+  }
+
+  const isRTL = () =>
+    typeof document === 'undefined'
+      ? false
+      : (document.dir || document.documentElement.dir || 'ltr') === 'rtl'
+
+  const field = useFormField(
+    () => ({
+      id: merged.id,
+      name: merged.name,
+      size: merged.size,
+      disabled: merged.disabled,
+    }),
+    () => ({
+      defaultId: generatedId(),
+      defaultSize: 'md',
+    }),
+  )
+
+  const getSliderEdges = createMemo(() =>
+    resolveSliderEdges(merged.orientation, merged.inverted, isRTL()),
+  )
+  const isActionDisabled = createMemo(() => field.disabled() || merged.readOnly)
+  const currentValues = createMemo(() => getControlledValues() ?? displayValues())
+  const interactionValues = () => pendingValues ?? currentValues()
+  const thumbStyles = createMemo<JSX.CSSProperties[]>(() => {
+    const { startEdge } = getSliderEdges()
+
+    return currentValues().map((value) => ({
+      [startEdge]: `${getValuePercent(value) * 100}%`,
+    }))
+  })
+  const dividerIndexes = createMemo(() => {
+    const step = definedStep()
+    if (!merged.divider || !step || merged.max! <= merged.min!) {
+      return []
+    }
+
+    const dividerCount = Math.floor((merged.max! - merged.min!) / step)
+    return Array.from({ length: Math.max(dividerCount - 1, 0) }, (_, index) => index + 1)
+  })
+  const getDividerStyle = (index: number): JSX.CSSProperties => {
+    const { startEdge } = getSliderEdges()
+    const value = merged.min! + keyboardStep() * index
+
+    return {
+      [startEdge]: `${getValuePercent(value) * 100}%`,
+      ...merged.styles?.divider,
+    }
+  }
+  const rangeStyle = createMemo<JSX.CSSProperties>(() => {
+    const percentages = currentValues().map((value) => getValuePercent(value) * 100)
+    const offsetStart = currentValues().length > 1 ? Math.min(...percentages) : 0
+    const offsetEnd = 100 - Math.max(...percentages)
+    const { startEdge, endEdge } = getSliderEdges()
+
+    return {
+      [startEdge]: `${offsetStart}%`,
+      [endEdge]: `${offsetEnd}%`,
+    }
+  })
+
+  onMount(() => {
+    const initialValue = normalizeSliderValues(merged.defaultValue, merged.min ?? 0) ?? [
+      merged.min ?? 0,
+    ]
+
+    if (getControlledValues() === undefined) {
+      setDisplayValues(initialValue)
+    }
+
+    if (field.value() === undefined) {
+      field.setFormValue(toPublicValue(initialValue))
+    }
+  })
+
+  createEffect(() => {
+    const nextControlledValues = getControlledValues()
+    if (nextControlledValues !== undefined) {
+      setDisplayValues(nextControlledValues)
+    }
+  })
+
+  function toPublicValue(values: number[]): TValue {
+    if (Array.isArray(merged.value) || Array.isArray(merged.defaultValue)) {
+      return [...values] as TValue
+    }
+
+    return (values[0] ?? merged.min!) as TValue
+  }
+
+  function getThumbMinValue(values: number[], index: number): number {
+    const thumbGap = merged.minStepsBetweenThumbs! * keyboardStep()
+    return index === 0
+      ? merged.min!
+      : clamp((values[index - 1] ?? merged.min!) + thumbGap, merged.min!, merged.max!)
+  }
+
+  function getThumbMaxValue(values: number[], index: number): number {
+    const thumbGap = merged.minStepsBetweenThumbs! * keyboardStep()
+    return index === values.length - 1
+      ? merged.max!
+      : clamp((values[index + 1] ?? merged.max!) - thumbGap, merged.min!, merged.max!)
+  }
+
+  function getValueFromPointer(pointerPosition: number): number {
+    const rect = trackElement()?.getBoundingClientRect()
+    if (!rect) {
+      return merged.min!
+    }
+
+    const orientation = merged.orientation
+    const input: [number, number] = [0, orientation === 'vertical' ? rect.height : rect.width]
+
+    let output: [number, number] =
+      orientation === 'vertical'
+        ? merged.inverted
+          ? [merged.min!, merged.max!]
+          : [merged.max!, merged.min!]
+        : merged.inverted
+          ? [merged.max!, merged.min!]
+          : [merged.min!, merged.max!]
+
+    const value = linearScale(input, output)
+    const offset = orientation === 'vertical' ? rect.top : rect.left
+
+    return clamp(value(pointerPosition - offset), merged.min!, merged.max!)
+  }
+
+  function startInteraction(index: number, event: PointerEvent): void {
+    const target = event.currentTarget as HTMLDivElement
+
+    activePointerId = event.pointerId
+    setActiveThumbIndex(index)
+    lastPointerPosition = merged.orientation === 'vertical' ? event.clientY : event.clientX
+    pendingValues = undefined
+    setDragging(true)
+
+    target.setPointerCapture(event.pointerId)
+    event.preventDefault()
+    event.stopPropagation()
+  }
+
+  function commitPendingValues(): void {
+    if (!pendingValues) {
+      return
+    }
+
+    const nextValue = toPublicValue(pendingValues)
+    field.setFormValue(nextValue)
+    merged.onChange?.(nextValue)
+    field.emit('change')
+    pendingValues = undefined
+  }
+
+  function finishInteraction(event: PointerEvent, target: HTMLDivElement): void {
+    if (activePointerId !== event.pointerId) {
+      return
+    }
+
+    if (target.hasPointerCapture(event.pointerId)) {
+      target.releasePointerCapture(event.pointerId)
+    }
+
+    activePointerId = undefined
+    setActiveThumbIndex(undefined)
+    lastPointerPosition = 0
+    setDragging(false)
+    commitPendingValues()
+  }
+
+  function getResolvedThumbValues(
+    values: number[],
+    index: number,
+    candidateValue: number,
+  ): { nextIndex: number; nextValues: number[] } | undefined {
+    const allowsThumbCrossing = merged.allowThumbCrossing && merged.minStepsBetweenThumbs === 0
+    const minValue = allowsThumbCrossing ? merged.min! : getThumbMinValue(values, index)
+    const maxValue = allowsThumbCrossing ? merged.max! : getThumbMaxValue(values, index)
+    const step = definedStep()
+    const nextValue = step
+      ? snapValueToStep(candidateValue, minValue, maxValue, step)
+      : clamp(candidateValue, minValue, maxValue)
+
+    let nextValues: number[]
+    let nextIndex = index
+
+    if (allowsThumbCrossing) {
+      const movedValue = moveSortedValue(values, nextValue, index)
+      nextValues = movedValue.nextValues
+      nextIndex = movedValue.nextIndex
+    } else {
+      nextValues = [...values]
+      nextValues[index] = nextValue
+
+      if (
+        !hasMinStepsBetweenValues(
+          getNextSortedValues(values, nextValue, index),
+          merged.minStepsBetweenThumbs! * keyboardStep(),
+        )
+      ) {
+        return undefined
+      }
+    }
+
+    return { nextIndex, nextValues }
+  }
+
+  function applyThumbValue(index: number, candidateValue: number): number | undefined {
+    if (isActionDisabled()) {
+      return undefined
+    }
+
+    const resolvedValues = getResolvedThumbValues(interactionValues(), index, candidateValue)
+    if (!resolvedValues) {
+      return undefined
+    }
+
+    const { nextIndex, nextValues } = resolvedValues
+
+    pendingValues = nextValues
+    setDisplayValues(nextValues)
+
+    const publicValue = toPublicValue(nextValues)
+    field.setFormValue(publicValue)
+    merged.onValueChange?.(publicValue)
+    field.emit('input')
+
+    return nextIndex
+  }
+
+  function focusThumb(index: number): void {
+    const thumb = thumbRefs()[index]
+    if (!thumb || document.activeElement === thumb) {
+      return
+    }
+
+    suppressNextBlurCommit = true
+    thumb.focus()
+  }
+
+  function moveThumb(index: number, pointerValue: number): void {
+    const nextIndex = applyThumbValue(index, pointerValue)
+
+    if (nextIndex !== undefined && nextIndex !== index) {
+      setActiveThumbIndex(nextIndex)
+      focusThumb(nextIndex)
+    }
+  }
+
+  function getClosestThumbIndex(values: number[], pointerValue: number): number {
+    // Match established slider behavior: when stacked thumbs are equally close,
+    // keep manipulating the thumb the user most recently focused or dragged.
+    const closestIndex = getClosestValueIndex(values, pointerValue)
+    if (lastUsedThumbIndex === undefined || values.length < 2) {
+      return closestIndex
+    }
+
+    const closestDistance = Math.abs((values[closestIndex] ?? pointerValue) - pointerValue)
+    const lastUsedDistance = Math.abs((values[lastUsedThumbIndex] ?? pointerValue) - pointerValue)
+    return lastUsedDistance === closestDistance ? lastUsedThumbIndex : closestIndex
+  }
+
+  function handlePointerMove(event: PointerEvent): void {
+    if (isActionDisabled() || activePointerId !== event.pointerId) {
+      return
+    }
+
+    const target = event.currentTarget as HTMLDivElement
+    if (!target.hasPointerCapture(event.pointerId) || activeThumbIndex === undefined) {
+      return
+    }
+
+    const pointerPosition = merged.orientation === 'vertical' ? event.clientY : event.clientX
+    const delta = pointerPosition - lastPointerPosition
+    if (delta === 0) {
+      return
+    }
+
+    lastPointerPosition = pointerPosition
+    moveThumb(activeThumbIndex, getValueFromPointer(pointerPosition))
+  }
+
+  function onTrackPointerDown(event: PointerEvent): void {
+    if (isActionDisabled() || event.button !== 0) {
+      return
+    }
+
+    const pointerPosition = merged.orientation === 'vertical' ? event.clientY : event.clientX
+    const pointerValue = getValueFromPointer(pointerPosition)
+    const nextActiveThumbIndex = getClosestThumbIndex(interactionValues(), pointerValue)
+    startInteraction(nextActiveThumbIndex, event)
+    applyThumbValue(nextActiveThumbIndex, pointerValue)
+    focusThumb(nextActiveThumbIndex)
+  }
+
+  function onTrackPointerMove(event: PointerEvent): void {
+    handlePointerMove(event)
+  }
+
+  function onTrackPointerUp(event: PointerEvent): void {
+    const target = event.currentTarget as HTMLDivElement
+    finishInteraction(event, target)
+  }
+
+  function onPointerCancel(event: PointerEvent): void {
+    const target = event.currentTarget as HTMLDivElement
+    finishInteraction(event, target)
+  }
+
+  function onThumbPointerDown(index: number, event: PointerEvent): void {
+    if (isActionDisabled() || event.button !== 0) {
+      return
+    }
+
+    startInteraction(index, event)
+    const target = event.currentTarget as HTMLDivElement
+    if (merged.variant === 'bold') {
+      target.blur()
+      return
+    }
+
+    target.focus()
+  }
+
+  function onThumbPointerMove(event: PointerEvent): void {
+    handlePointerMove(event)
+  }
+
+  function onThumbPointerUp(event: PointerEvent): void {
+    const target = event.currentTarget as HTMLDivElement
+    finishInteraction(event, target)
+  }
+
+  function onThumbKeyDown(index: number, event: KeyboardEvent): void {
+    if (isActionDisabled()) {
+      return
+    }
+
+    const key = event.key === 'Spacebar' ? ' ' : event.key
+    const isIncrementKey =
+      key === 'ArrowRight' || key === 'ArrowUp' || key === 'Right' || key === 'Up'
+    const isDecrementKey =
+      key === 'ArrowLeft' || key === 'ArrowDown' || key === 'Left' || key === 'Down'
+    const isPageUp = key === 'PageUp'
+    const isPageDown = key === 'PageDown'
+    const isLTR = () =>
+      typeof document === 'undefined'
+        ? true
+        : (document.dir || document.documentElement.dir || 'ltr') !== 'rtl'
+
+    if (
+      !isIncrementKey &&
+      !isDecrementKey &&
+      key !== 'Home' &&
+      key !== 'End' &&
+      !isPageUp &&
+      !isPageDown
+    ) {
+      return
+    }
+
+    event.preventDefault()
+
+    if (key === 'Home') {
+      applyThumbValue(index, getThumbMinValue(interactionValues(), index))
+      return
+    }
+
+    if (key === 'End') {
+      applyThumbValue(index, getThumbMaxValue(interactionValues(), index))
+      return
+    }
+
+    let direction = 0
+    if (isPageUp) {
+      direction = 1
+    } else if (isPageDown) {
+      direction = -1
+    } else if (merged.orientation === 'vertical') {
+      if (key === 'ArrowDown' || key === 'Down') {
+        direction = merged.inverted ? 1 : -1
+      } else if (key === 'ArrowUp' || key === 'Up') {
+        direction = merged.inverted ? -1 : 1
+      } else if (isIncrementKey) {
+        direction = isLTR() ? 1 : -1
+      } else if (isDecrementKey) {
+        direction = isLTR() ? -1 : 1
+      }
+    } else if (isIncrementKey) {
+      direction = isLTR() ? 1 : -1
+    } else if (isDecrementKey) {
+      direction = isLTR() ? -1 : 1
+    }
+
+    const stepSize = isPageUp || isPageDown || event.shiftKey ? pageSize() : keyboardStep()
+
+    const oldValue = interactionValues()[index] ?? merged.min!
+    const candidateValue = oldValue + direction * stepSize
+    applyThumbValue(index, candidateValue)
+    const newValue = interactionValues()[index] ?? merged.min!
+
+    if (!merged.allowThumbCrossing && interactionValues().length > 1 && newValue === oldValue) {
+      const atGlobalBoundary =
+        (direction > 0 && oldValue === merged.max!) || (direction < 0 && oldValue === merged.min!)
+      if (!atGlobalBoundary) {
+        const adjacentIndex = direction > 0 ? index + 1 : index - 1
+        if (adjacentIndex >= 0 && adjacentIndex < interactionValues().length) {
+          focusThumb(adjacentIndex)
+        }
+      }
+    }
+  }
+
+  function onThumbFocus(index: number): void {
+    lastUsedThumbIndex = index
+    field.emit('focus')
+  }
+
+  function onThumbKeyUp(event: KeyboardEvent): void {
+    if (isActionDisabled()) {
+      return
+    }
+
+    const key = event.key === 'Spacebar' ? ' ' : event.key
+    const isNavigationKey =
+      key === 'ArrowRight' ||
+      key === 'ArrowUp' ||
+      key === 'ArrowLeft' ||
+      key === 'ArrowDown' ||
+      key === 'Right' ||
+      key === 'Up' ||
+      key === 'Left' ||
+      key === 'Down' ||
+      key === 'Home' ||
+      key === 'End' ||
+      key === 'PageUp' ||
+      key === 'PageDown'
+
+    if (!isNavigationKey) {
+      return
+    }
+
+    commitPendingValues()
+  }
+
+  function onThumbBlur(): void {
+    field.emit('blur')
+
+    if (suppressNextBlurCommit) {
+      suppressNextBlurCommit = false
+      return
+    }
+
+    commitPendingValues()
+  }
+
+  function getValuePercent(value: number): number {
+    const range = merged.max! - merged.min!
+    if (range <= 0) {
+      return 0
+    }
+
+    return (value - merged.min!) / range
+  }
+
+  function getThumbValueText(index: number): string {
+    return String(currentValues()[index] ?? merged.min!)
+  }
+
+  return {
+    activeThumbIndexState,
+    currentValues,
+    definedStep,
+    dividerIndexes,
+    dragging,
+    field,
+    getDividerStyle,
+    getThumbMaxValue,
+    getThumbMinValue,
+    getThumbValueText,
+    onThumbBlur,
+    onThumbFocus,
+    onThumbKeyDown,
+    onThumbKeyUp,
+    onPointerCancel,
+    onThumbPointerDown,
+    onThumbPointerMove,
+    onThumbPointerUp,
+    onTrackPointerDown,
+    onTrackPointerMove,
+    onTrackPointerUp,
+    rangeStyle,
+    setThumbRefs,
+    setTrackElementState,
+    thumbStyles,
+  }
+}

--- a/src/forms/slider/hook/use-slider.ts
+++ b/src/forms/slider/hook/use-slider.ts
@@ -1,9 +1,7 @@
 import type { JSX } from 'solid-js'
 import { createEffect, createMemo, createSignal, onMount } from 'solid-js'
 
-import { useId } from '../../../shared/utils'
-import { useFormField } from '../../form-field/form-field-context'
-import type { SliderProps, SliderT } from '../slider'
+import type { SliderVariantProps } from '../slider.class'
 import {
   clamp,
   getClosestValueIndex,
@@ -15,20 +13,32 @@ import {
   resolveSliderEdges,
   snapValueToStep,
 } from '../utils'
+import type { SliderValue } from '../utils'
 
-type UseSliderProps<TValue extends SliderT.Value> = SliderProps<TValue> & {
+type UseSliderProps<TValue extends SliderValue> = {
   allowThumbCrossing: boolean
+  defaultValue?: TValue
+  disabled?: boolean
+  divider?: boolean
   inverted: boolean
   max: number
   min: number
   minStepsBetweenThumbs: number
   orientation: 'horizontal' | 'vertical'
+  readOnly?: boolean
+  step?: number
+  styles?: { divider?: JSX.CSSProperties }
+  value?: TValue
+  variant?: SliderVariantProps['variant']
+  onBlur?: () => void
+  onFocus?: () => void
+  onValueCommit?: (value: TValue) => void
+  onValueInput?: (value: TValue) => void
 }
 
-export function useSlider<TValue extends SliderT.Value = SliderT.Value>(
+export function useSlider<TValue extends SliderValue = SliderValue>(
   merged: UseSliderProps<TValue>,
 ) {
-  const generatedId = useId(() => merged.id, 'slider')
   const [displayValues, setDisplayValues] = createSignal<number[]>([])
   const getControlledValues = () => normalizeSliderValues(merged.value, merged.min!)
 
@@ -75,23 +85,10 @@ export function useSlider<TValue extends SliderT.Value = SliderT.Value>(
       ? false
       : (document.dir || document.documentElement.dir || 'ltr') === 'rtl'
 
-  const field = useFormField(
-    () => ({
-      id: merged.id,
-      name: merged.name,
-      size: merged.size,
-      disabled: merged.disabled,
-    }),
-    () => ({
-      defaultId: generatedId(),
-      defaultSize: 'md',
-    }),
-  )
-
   const getSliderEdges = createMemo(() =>
     resolveSliderEdges(merged.orientation, merged.inverted, isRTL()),
   )
-  const isActionDisabled = createMemo(() => field.disabled() || merged.readOnly)
+  const isActionDisabled = createMemo(() => merged.disabled || merged.readOnly)
   const currentValues = createMemo(() => getControlledValues() ?? displayValues())
   const interactionValues = () => pendingValues ?? currentValues()
   const thumbStyles = createMemo<JSX.CSSProperties[]>(() => {
@@ -139,10 +136,6 @@ export function useSlider<TValue extends SliderT.Value = SliderT.Value>(
     if (getControlledValues() === undefined) {
       setDisplayValues(initialValue)
     }
-
-    if (field.value() === undefined) {
-      field.setFormValue(toPublicValue(initialValue))
-    }
   })
 
   createEffect(() => {
@@ -152,7 +145,7 @@ export function useSlider<TValue extends SliderT.Value = SliderT.Value>(
     }
   })
 
-  function toPublicValue(values: number[]): TValue {
+  function getPublicValue(values: number[]): TValue {
     if (Array.isArray(merged.value) || Array.isArray(merged.defaultValue)) {
       return [...values] as TValue
     }
@@ -217,10 +210,7 @@ export function useSlider<TValue extends SliderT.Value = SliderT.Value>(
       return
     }
 
-    const nextValue = toPublicValue(pendingValues)
-    field.setFormValue(nextValue)
-    merged.onChange?.(nextValue)
-    field.emit('change')
+    merged.onValueCommit?.(getPublicValue(pendingValues))
     pendingValues = undefined
   }
 
@@ -292,10 +282,7 @@ export function useSlider<TValue extends SliderT.Value = SliderT.Value>(
     pendingValues = nextValues
     setDisplayValues(nextValues)
 
-    const publicValue = toPublicValue(nextValues)
-    field.setFormValue(publicValue)
-    merged.onValueChange?.(publicValue)
-    field.emit('input')
+    merged.onValueInput?.(getPublicValue(nextValues))
 
     return nextIndex
   }
@@ -485,7 +472,7 @@ export function useSlider<TValue extends SliderT.Value = SliderT.Value>(
 
   function onThumbFocus(index: number): void {
     lastUsedThumbIndex = index
-    field.emit('focus')
+    merged.onFocus?.()
   }
 
   function onThumbKeyUp(event: KeyboardEvent): void {
@@ -516,7 +503,7 @@ export function useSlider<TValue extends SliderT.Value = SliderT.Value>(
   }
 
   function onThumbBlur(): void {
-    field.emit('blur')
+    merged.onBlur?.()
 
     if (suppressNextBlurCommit) {
       suppressNextBlurCommit = false
@@ -545,8 +532,8 @@ export function useSlider<TValue extends SliderT.Value = SliderT.Value>(
     definedStep,
     dividerIndexes,
     dragging,
-    field,
     getDividerStyle,
+    getPublicValue,
     getThumbMaxValue,
     getThumbMinValue,
     getThumbValueText,

--- a/src/forms/slider/hook/use-slider.ts
+++ b/src/forms/slider/hook/use-slider.ts
@@ -1,4 +1,4 @@
-import type { JSX } from 'solid-js'
+import type { JSX, Setter } from 'solid-js'
 import { createEffect, createMemo, createSignal, onMount } from 'solid-js'
 
 import type { SliderVariantProps } from '../slider.class'
@@ -18,7 +18,6 @@ import type { SliderValue } from '../utils'
 type UseSliderProps<TValue extends SliderValue> = {
   allowThumbCrossing: boolean
   defaultValue?: TValue
-  disabled?: boolean
   divider?: boolean
   inverted: boolean
   max: number
@@ -30,15 +29,48 @@ type UseSliderProps<TValue extends SliderValue> = {
   styles?: { divider?: JSX.CSSProperties }
   value?: TValue
   variant?: SliderVariantProps['variant']
+}
+
+type UseSliderOptions<TValue extends SliderValue> = {
+  disabled?: () => boolean | undefined
   onBlur?: () => void
   onFocus?: () => void
   onValueCommit?: (value: TValue) => void
   onValueInput?: (value: TValue) => void
 }
 
+export type UseSliderReturn<TValue extends SliderValue = SliderValue> = {
+  activeThumbIndexState: () => number | undefined
+  currentValues: () => number[]
+  definedStep: () => number | undefined
+  dividerIndexes: () => number[]
+  dragging: () => boolean
+  getDividerStyle: (index: number) => JSX.CSSProperties
+  getPublicValue: (values: number[]) => TValue
+  getThumbMaxValue: (index: number) => number
+  getThumbMinValue: (index: number) => number
+  getThumbValueText: (index: number) => string
+  onPointerCancel: (event: PointerEvent) => void
+  onThumbBlur: () => void
+  onThumbFocus: (index: number) => void
+  onThumbKeyDown: (index: number, event: KeyboardEvent) => void
+  onThumbKeyUp: (event: KeyboardEvent) => void
+  onThumbPointerDown: (index: number, event: PointerEvent) => void
+  onThumbPointerMove: (event: PointerEvent) => void
+  onThumbPointerUp: (event: PointerEvent) => void
+  onTrackPointerDown: (event: PointerEvent) => void
+  onTrackPointerMove: (event: PointerEvent) => void
+  onTrackPointerUp: (event: PointerEvent) => void
+  rangeStyle: () => JSX.CSSProperties
+  setThumbRefs: Setter<Array<HTMLDivElement | undefined>>
+  setTrackRef: Setter<HTMLDivElement | undefined>
+  thumbStyles: () => JSX.CSSProperties[]
+}
+
 export function useSlider<TValue extends SliderValue = SliderValue>(
   merged: UseSliderProps<TValue>,
-) {
+  options: UseSliderOptions<TValue> = {},
+): UseSliderReturn<TValue> {
   const [displayValues, setDisplayValues] = createSignal<number[]>([])
   const getControlledValues = () => normalizeSliderValues(merged.value, merged.min!)
 
@@ -61,7 +93,7 @@ export function useSlider<TValue extends SliderValue = SliderValue>(
     return Math.max(calcPageSize, step)
   })
   const [thumbRefs, setThumbRefs] = createSignal<Array<HTMLDivElement | undefined>>([])
-  const [trackElement, setTrackElementState] = createSignal<HTMLDivElement | undefined>(undefined)
+  const [trackElement, setTrackRef] = createSignal<HTMLDivElement | undefined>(undefined)
   const [activeThumbIndexState, setActiveThumbIndexState] = createSignal<number | undefined>(
     undefined,
   )
@@ -88,7 +120,7 @@ export function useSlider<TValue extends SliderValue = SliderValue>(
   const getSliderEdges = createMemo(() =>
     resolveSliderEdges(merged.orientation, merged.inverted, isRTL()),
   )
-  const isActionDisabled = createMemo(() => merged.disabled || merged.readOnly)
+  const isActionDisabled = createMemo(() => options.disabled?.() || merged.readOnly)
   const currentValues = createMemo(() => getControlledValues() ?? displayValues())
   const interactionValues = () => pendingValues ?? currentValues()
   const thumbStyles = createMemo<JSX.CSSProperties[]>(() => {
@@ -153,18 +185,26 @@ export function useSlider<TValue extends SliderValue = SliderValue>(
     return (values[0] ?? merged.min!) as TValue
   }
 
-  function getThumbMinValue(values: number[], index: number): number {
+  function getThumbMinValueFor(values: number[], index: number): number {
     const thumbGap = merged.minStepsBetweenThumbs! * keyboardStep()
     return index === 0
       ? merged.min!
       : clamp((values[index - 1] ?? merged.min!) + thumbGap, merged.min!, merged.max!)
   }
 
-  function getThumbMaxValue(values: number[], index: number): number {
+  function getThumbMaxValueFor(values: number[], index: number): number {
     const thumbGap = merged.minStepsBetweenThumbs! * keyboardStep()
     return index === values.length - 1
       ? merged.max!
       : clamp((values[index + 1] ?? merged.max!) - thumbGap, merged.min!, merged.max!)
+  }
+
+  function getThumbMinValue(index: number): number {
+    return getThumbMinValueFor(currentValues(), index)
+  }
+
+  function getThumbMaxValue(index: number): number {
+    return getThumbMaxValueFor(currentValues(), index)
   }
 
   function getValueFromPointer(pointerPosition: number): number {
@@ -210,7 +250,7 @@ export function useSlider<TValue extends SliderValue = SliderValue>(
       return
     }
 
-    merged.onValueCommit?.(getPublicValue(pendingValues))
+    options.onValueCommit?.(getPublicValue(pendingValues))
     pendingValues = undefined
   }
 
@@ -236,8 +276,8 @@ export function useSlider<TValue extends SliderValue = SliderValue>(
     candidateValue: number,
   ): { nextIndex: number; nextValues: number[] } | undefined {
     const allowsThumbCrossing = merged.allowThumbCrossing && merged.minStepsBetweenThumbs === 0
-    const minValue = allowsThumbCrossing ? merged.min! : getThumbMinValue(values, index)
-    const maxValue = allowsThumbCrossing ? merged.max! : getThumbMaxValue(values, index)
+    const minValue = allowsThumbCrossing ? merged.min! : getThumbMinValueFor(values, index)
+    const maxValue = allowsThumbCrossing ? merged.max! : getThumbMaxValueFor(values, index)
     const step = definedStep()
     const nextValue = step
       ? snapValueToStep(candidateValue, minValue, maxValue, step)
@@ -282,7 +322,7 @@ export function useSlider<TValue extends SliderValue = SliderValue>(
     pendingValues = nextValues
     setDisplayValues(nextValues)
 
-    merged.onValueInput?.(getPublicValue(nextValues))
+    options.onValueInput?.(getPublicValue(nextValues))
 
     return nextIndex
   }
@@ -421,12 +461,12 @@ export function useSlider<TValue extends SliderValue = SliderValue>(
     event.preventDefault()
 
     if (key === 'Home') {
-      applyThumbValue(index, getThumbMinValue(interactionValues(), index))
+      applyThumbValue(index, getThumbMinValueFor(interactionValues(), index))
       return
     }
 
     if (key === 'End') {
-      applyThumbValue(index, getThumbMaxValue(interactionValues(), index))
+      applyThumbValue(index, getThumbMaxValueFor(interactionValues(), index))
       return
     }
 
@@ -472,7 +512,7 @@ export function useSlider<TValue extends SliderValue = SliderValue>(
 
   function onThumbFocus(index: number): void {
     lastUsedThumbIndex = index
-    merged.onFocus?.()
+    options.onFocus?.()
   }
 
   function onThumbKeyUp(event: KeyboardEvent): void {
@@ -503,7 +543,7 @@ export function useSlider<TValue extends SliderValue = SliderValue>(
   }
 
   function onThumbBlur(): void {
-    merged.onBlur?.()
+    options.onBlur?.()
 
     if (suppressNextBlurCommit) {
       suppressNextBlurCommit = false
@@ -550,7 +590,7 @@ export function useSlider<TValue extends SliderValue = SliderValue>(
     onTrackPointerUp,
     rangeStyle,
     setThumbRefs,
-    setTrackElementState,
+    setTrackRef,
     thumbStyles,
   }
 }

--- a/src/forms/slider/index.ts
+++ b/src/forms/slider/index.ts
@@ -1,1 +1,2 @@
 export * from './slider'
+export * from './hook'

--- a/src/forms/slider/slider.test.tsx
+++ b/src/forms/slider/slider.test.tsx
@@ -1210,5 +1210,56 @@ describe('Slider', () => {
       expect(onChange).toHaveBeenCalledTimes(1)
       expect(onChange).toHaveBeenLastCalledWith(60)
     })
+
+    test('track press reuses the last focused overlapping thumb', async () => {
+      const screen = render(() => <Slider defaultValue={[20, 20]} />)
+      const thumbs = getThumbs(screen.container)
+      const track = screen.container.querySelector('[data-slot="track"]') as HTMLElement
+
+      mockPointerCapture(track)
+      mockTrackRect(track)
+
+      await fireEvent.focus(thumbs[0] as HTMLElement)
+      await fireEvent.pointerDown(track, {
+        button: 0,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 0,
+      })
+
+      expect(document.activeElement).toBe(thumbs[0])
+    })
+
+    test('pointer cancel commits pending drag values', async () => {
+      const onChange = vi.fn()
+      const screen = render(() => <Slider defaultValue={20} onChange={onChange} />)
+      const thumb = getThumbs(screen.container)[0] as HTMLElement
+      const track = screen.container.querySelector('[data-slot="track"]') as HTMLElement
+
+      mockPointerCapture(thumb)
+      mockTrackRect(track)
+
+      await fireEvent.pointerDown(thumb, {
+        button: 0,
+        pointerId: 1,
+        clientX: 20,
+        clientY: 0,
+      })
+      await fireEvent.pointerMove(thumb, {
+        pointerId: 1,
+        clientX: 45,
+        clientY: 0,
+      })
+
+      expect(onChange).not.toHaveBeenCalled()
+
+      await fireEvent.pointerCancel(thumb, {
+        pointerId: 1,
+        clientX: 45,
+        clientY: 0,
+      })
+
+      expect(onChange).toHaveBeenLastCalledWith(45)
+    })
   })
 })

--- a/src/forms/slider/slider.tsx
+++ b/src/forms/slider/slider.tsx
@@ -237,7 +237,7 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
             <div
               data-slot="divider"
               data-orientation={merged.orientation}
-              style={slider.getDividerStyle(dividerIndex)}
+              style={{ ...slider.getDividerStyle(dividerIndex), ...merged.styles?.divider }}
               class={sliderDividerVariants(
                 {
                   orientation: merged.orientation,

--- a/src/forms/slider/slider.tsx
+++ b/src/forms/slider/slider.tsx
@@ -1,8 +1,10 @@
 import type { JSX } from 'solid-js'
-import { For, mergeProps } from 'solid-js'
+import { For, mergeProps, onMount } from 'solid-js'
 
 import { HiddenInput } from '../../shared/hidden-input'
 import type { BaseProps, SlotClassValue, SlotStyleValue } from '../../shared/types'
+import { useId } from '../../shared/utils'
+import { useFormField } from '../form-field/form-field-context'
 import type {
   FormDisableOption,
   FormIdentityOptions,
@@ -135,21 +137,62 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
     props,
   )
 
-  const slider = useSlider(merged)
+  const generatedId = useId(() => merged.id, 'slider')
+  const field = useFormField(
+    () => ({
+      id: merged.id,
+      name: merged.name,
+      size: merged.size,
+      disabled: merged.disabled,
+    }),
+    () => ({
+      defaultId: generatedId(),
+      defaultSize: 'md',
+    }),
+  )
+  const sliderOptions = mergeProps(merged, {
+    get disabled() {
+      return field.disabled()
+    },
+    onValueInput(value: TValue) {
+      field.setFormValue(value)
+      merged.onValueChange?.(value)
+      field.emit('input')
+    },
+    onValueCommit(value: TValue) {
+      field.setFormValue(value)
+      merged.onChange?.(value)
+      field.emit('change')
+    },
+    onFocus() {
+      field.emit('focus')
+    },
+    onBlur() {
+      field.emit('blur')
+    },
+  })
+  const slider = useSlider(sliderOptions)
+
+  onMount(() => {
+    if (field.value() === undefined) {
+      field.setFormValue(slider.getPublicValue(slider.currentValues()))
+    }
+  })
+
   return (
     <div
-      id={`${slider.field.id()}-root`}
+      id={`${field.id()}-root`}
       role="group"
       data-slot="root"
       data-orientation={merged.orientation}
-      data-disabled={slider.field.disabled() ? '' : undefined}
-      data-invalid={slider.field.invalid() ? '' : undefined}
+      data-disabled={field.disabled() ? '' : undefined}
+      data-invalid={field.invalid() ? '' : undefined}
       data-readonly={merged.readOnly ? '' : undefined}
       data-required={merged.required ? '' : undefined}
       style={{ ...merged.styles?.root, ...merged.style }}
       class={sliderRootVariants(
         { orientation: merged.orientation },
-        slider.field.disabled() && 'effect-dis',
+        field.disabled() && 'effect-dis',
         merged.classes?.root,
         merged.class,
       )}
@@ -163,7 +206,7 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
         style={merged.styles?.track}
         class={sliderTrackVariants(
           {
-            size: slider.field.size(),
+            size: field.size(),
             orientation: merged.orientation,
             variant: merged.variant,
           },
@@ -224,12 +267,12 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
             data-dragging={
               slider.dragging() && slider.activeThumbIndexState() === thumbIndex ? '' : undefined
             }
-            data-disabled={slider.field.disabled() ? '' : undefined}
-            data-invalid={slider.field.invalid() ? '' : undefined}
+            data-disabled={field.disabled() ? '' : undefined}
+            data-invalid={field.invalid() ? '' : undefined}
             data-readonly={merged.readOnly ? '' : undefined}
             data-required={merged.required ? '' : undefined}
             role="slider"
-            tabIndex={slider.field.disabled() ? undefined : 0}
+            tabIndex={field.disabled() ? undefined : 0}
             style={{
               ...slider.thumbStyles()[thumbIndex],
               ...merged.styles?.thumb,
@@ -238,7 +281,7 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
               {
                 inverted: merged.inverted,
                 orientation: merged.orientation,
-                size: slider.field.size(),
+                size: field.size(),
                 variant: merged.variant,
               },
               merged.classes?.thumb,
@@ -254,7 +297,7 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
                 : `Thumb ${thumbIndex + 1} of ${slider.currentValues().length}`
             }
             aria-required={merged.required || undefined}
-            aria-disabled={slider.field.disabled() || undefined}
+            aria-disabled={field.disabled() || undefined}
             aria-readonly={merged.readOnly || undefined}
             onPointerDown={(event) => {
               slider.onThumbPointerDown(thumbIndex, event)
@@ -278,22 +321,22 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
           >
             <HiddenInput
               type="range"
-              id={slider.field.id() + (thumbIndex === 0 ? '' : `-${thumbIndex + 1}`)}
-              name={slider.field.name()}
+              id={field.id() + (thumbIndex === 0 ? '' : `-${thumbIndex + 1}`)}
+              name={field.name()}
               min={slider.getThumbMinValue(slider.currentValues(), thumbIndex)}
               max={slider.getThumbMaxValue(slider.currentValues(), thumbIndex)}
               step={slider.definedStep() ?? 'any'}
               value={slider.currentValues()[thumbIndex] ?? merged.min!}
               required={merged.required}
-              disabled={slider.field.disabled()}
+              disabled={field.disabled()}
               readOnly={merged.readOnly}
-              tabIndex={slider.field.disabled() ? undefined : -1}
+              tabIndex={field.disabled() ? undefined : -1}
               aria-valuetext={slider.getThumbValueText(thumbIndex)}
               aria-orientation={merged.orientation}
               aria-required={merged.required || undefined}
-              aria-disabled={slider.field.disabled() || undefined}
+              aria-disabled={field.disabled() || undefined}
               aria-readonly={merged.readOnly || undefined}
-              {...slider.field.ariaAttrs()}
+              {...field.ariaAttrs()}
             />
           </div>
         )}

--- a/src/forms/slider/slider.tsx
+++ b/src/forms/slider/slider.tsx
@@ -1,10 +1,8 @@
 import type { JSX } from 'solid-js'
-import { For, createEffect, createMemo, createSignal, mergeProps, onMount } from 'solid-js'
+import { For, mergeProps } from 'solid-js'
 
 import { HiddenInput } from '../../shared/hidden-input'
 import type { BaseProps, SlotClassValue, SlotStyleValue } from '../../shared/types'
-import { useId } from '../../shared/utils'
-import { useFormField } from '../form-field/form-field-context'
 import type {
   FormDisableOption,
   FormIdentityOptions,
@@ -13,6 +11,7 @@ import type {
   FormValueOptions,
 } from '../form-field/form-options'
 
+import { useSlider } from './hook'
 import type { SliderVariantProps } from './slider.class'
 import {
   sliderDividerVariants,
@@ -21,17 +20,6 @@ import {
   sliderThumbVariants,
   sliderTrackVariants,
 } from './slider.class'
-import {
-  clamp,
-  getClosestValueIndex,
-  getNextSortedValues,
-  hasMinStepsBetweenValues,
-  linearScale,
-  moveSortedValue,
-  normalizeSliderValues,
-  resolveSliderEdges,
-  snapValueToStep,
-} from './utils'
 
 export namespace SliderT {
   export type Value = number | number[]
@@ -147,558 +135,51 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
     props,
   )
 
-  const generatedId = useId(() => merged.id, 'slider')
-  const [displayValues, setDisplayValues] = createSignal<number[]>([])
-  const getControlledValues = () => normalizeSliderValues(merged.value, merged.min!)
-
-  const [dragging, setDragging] = createSignal(false)
-  const definedStep = createMemo(() =>
-    typeof merged.step === 'number' && merged.step > 0 ? merged.step : undefined,
-  )
-  const keyboardStep = createMemo(() => {
-    const range = merged.max! - merged.min!
-    return definedStep() ?? (range > 0 ? range / 100 : 1)
-  })
-  const pageSize = createMemo(() => {
-    let calcPageSize = (merged.max! - merged.min!) / 10
-    const step = definedStep()
-    if (!step) {
-      return calcPageSize
-    }
-
-    calcPageSize = snapValueToStep(calcPageSize, 0, calcPageSize + step, step)
-    return Math.max(calcPageSize, step)
-  })
-  const [thumbRefs, setThumbRefs] = createSignal<Array<HTMLDivElement | undefined>>([])
-  const [trackElement, setTrackElementState] = createSignal<HTMLDivElement | undefined>(undefined)
-  const [activeThumbIndexState, setActiveThumbIndexState] = createSignal<number | undefined>(
-    undefined,
-  )
-  let pendingValues: number[] | undefined
-  let activePointerId: number | undefined
-  let activeThumbIndex: number | undefined
-  let lastPointerPosition = 0
-  let suppressNextBlurCommit = false
-
-  function setActiveThumbIndex(index: number | undefined): void {
-    activeThumbIndex = index
-    setActiveThumbIndexState(index)
-  }
-
-  const isRTL = () =>
-    typeof document === 'undefined'
-      ? false
-      : (document.dir || document.documentElement.dir || 'ltr') === 'rtl'
-
-  const field = useFormField(
-    () => ({
-      id: merged.id,
-      name: merged.name,
-      size: merged.size,
-      disabled: merged.disabled,
-    }),
-    () => ({
-      defaultId: generatedId(),
-      defaultSize: 'md',
-    }),
-  )
-
-  const getSliderEdges = createMemo(() =>
-    resolveSliderEdges(merged.orientation, merged.inverted, isRTL()),
-  )
-  const isActionDisabled = createMemo(() => field.disabled() || merged.readOnly)
-  const currentValues = createMemo(() => getControlledValues() ?? displayValues())
-  const interactionValues = () => pendingValues ?? currentValues()
-  const thumbStyles = createMemo<JSX.CSSProperties[]>(() => {
-    const { startEdge } = getSliderEdges()
-
-    return currentValues().map((value) => ({
-      [startEdge]: `${getValuePercent(value) * 100}%`,
-    }))
-  })
-  const dividerIndexes = createMemo(() => {
-    const step = definedStep()
-    if (!merged.divider || !step || merged.max! <= merged.min!) {
-      return []
-    }
-
-    const dividerCount = Math.floor((merged.max! - merged.min!) / step)
-    return Array.from({ length: Math.max(dividerCount - 1, 0) }, (_, index) => index + 1)
-  })
-  const getDividerStyle = (index: number): JSX.CSSProperties => {
-    const { startEdge } = getSliderEdges()
-    const value = merged.min! + keyboardStep() * index
-
-    return {
-      [startEdge]: `${getValuePercent(value) * 100}%`,
-      ...merged.styles?.divider,
-    }
-  }
-  const rangeStyle = createMemo<JSX.CSSProperties>(() => {
-    const percentages = currentValues().map((value) => getValuePercent(value) * 100)
-    const offsetStart = currentValues().length > 1 ? Math.min(...percentages) : 0
-    const offsetEnd = 100 - Math.max(...percentages)
-    const { startEdge, endEdge } = getSliderEdges()
-
-    return {
-      [startEdge]: `${offsetStart}%`,
-      [endEdge]: `${offsetEnd}%`,
-    }
-  })
-
-  onMount(() => {
-    const initialValue = normalizeSliderValues(props.defaultValue, props.min ?? 0) ?? [
-      props.min ?? 0,
-    ]
-
-    if (getControlledValues() === undefined) {
-      setDisplayValues(initialValue)
-    }
-
-    if (field.value() === undefined) {
-      field.setFormValue(toPublicValue(initialValue))
-    }
-  })
-
-  createEffect(() => {
-    const nextControlledValues = getControlledValues()
-    if (nextControlledValues !== undefined) {
-      setDisplayValues(nextControlledValues)
-    }
-  })
-
-  function toPublicValue(values: number[]): TValue {
-    if (Array.isArray(merged.value) || Array.isArray(merged.defaultValue)) {
-      return [...values] as TValue
-    }
-
-    return (values[0] ?? merged.min!) as TValue
-  }
-
-  function getThumbMinValue(values: number[], index: number): number {
-    const thumbGap = merged.minStepsBetweenThumbs! * keyboardStep()
-    return index === 0
-      ? merged.min!
-      : clamp((values[index - 1] ?? merged.min!) + thumbGap, merged.min!, merged.max!)
-  }
-
-  function getThumbMaxValue(values: number[], index: number): number {
-    const thumbGap = merged.minStepsBetweenThumbs! * keyboardStep()
-    return index === values.length - 1
-      ? merged.max!
-      : clamp((values[index + 1] ?? merged.max!) - thumbGap, merged.min!, merged.max!)
-  }
-
-  function getValueFromPointer(pointerPosition: number): number {
-    const rect = trackElement()?.getBoundingClientRect()
-    if (!rect) {
-      return merged.min!
-    }
-
-    const orientation = merged.orientation
-    const input: [number, number] = [0, orientation === 'vertical' ? rect.height : rect.width]
-
-    let output: [number, number] =
-      orientation === 'vertical'
-        ? merged.inverted
-          ? [merged.min!, merged.max!]
-          : [merged.max!, merged.min!]
-        : merged.inverted
-          ? [merged.max!, merged.min!]
-          : [merged.min!, merged.max!]
-
-    const value = linearScale(input, output)
-    const offset = orientation === 'vertical' ? rect.top : rect.left
-
-    return clamp(value(pointerPosition - offset), merged.min!, merged.max!)
-  }
-
-  function startInteraction(index: number, event: PointerEvent): void {
-    const target = event.currentTarget as HTMLDivElement
-
-    activePointerId = event.pointerId
-    setActiveThumbIndex(index)
-    lastPointerPosition = merged.orientation === 'vertical' ? event.clientY : event.clientX
-    pendingValues = undefined
-    setDragging(true)
-
-    target.setPointerCapture(event.pointerId)
-    event.preventDefault()
-    event.stopPropagation()
-  }
-
-  function finishInteraction(event: PointerEvent, target: HTMLDivElement): void {
-    if (activePointerId !== event.pointerId) {
-      return
-    }
-
-    if (target.hasPointerCapture(event.pointerId)) {
-      target.releasePointerCapture(event.pointerId)
-    }
-
-    activePointerId = undefined
-    setActiveThumbIndex(undefined)
-    lastPointerPosition = 0
-    setDragging(false)
-
-    if (!pendingValues) {
-      return
-    }
-
-    const nextValue = toPublicValue(pendingValues)
-    field.setFormValue(nextValue)
-    merged.onChange?.(nextValue)
-    field.emit('change')
-    pendingValues = undefined
-  }
-
-  function getResolvedThumbValues(
-    values: number[],
-    index: number,
-    candidateValue: number,
-  ): { nextIndex: number; nextValues: number[] } | undefined {
-    const allowsThumbCrossing = merged.allowThumbCrossing && merged.minStepsBetweenThumbs === 0
-    const minValue = allowsThumbCrossing ? merged.min! : getThumbMinValue(values, index)
-    const maxValue = allowsThumbCrossing ? merged.max! : getThumbMaxValue(values, index)
-    const step = definedStep()
-    const nextValue = step
-      ? snapValueToStep(candidateValue, minValue, maxValue, step)
-      : clamp(candidateValue, minValue, maxValue)
-
-    let nextValues: number[]
-    let nextIndex = index
-
-    if (allowsThumbCrossing) {
-      const movedValue = moveSortedValue(values, nextValue, index)
-      nextValues = movedValue.nextValues
-      nextIndex = movedValue.nextIndex
-    } else {
-      nextValues = [...values]
-      nextValues[index] = nextValue
-
-      if (
-        !hasMinStepsBetweenValues(
-          getNextSortedValues(values, nextValue, index),
-          merged.minStepsBetweenThumbs! * keyboardStep(),
-        )
-      ) {
-        return undefined
-      }
-    }
-
-    return { nextIndex, nextValues }
-  }
-
-  function applyThumbValue(index: number, candidateValue: number): number | undefined {
-    if (isActionDisabled()) {
-      return undefined
-    }
-
-    const resolvedValues = getResolvedThumbValues(interactionValues(), index, candidateValue)
-    if (!resolvedValues) {
-      return undefined
-    }
-
-    const { nextIndex, nextValues } = resolvedValues
-
-    pendingValues = nextValues
-    setDisplayValues(nextValues)
-
-    const publicValue = toPublicValue(nextValues)
-    field.setFormValue(publicValue)
-    merged.onValueChange?.(publicValue)
-    field.emit('input')
-
-    return nextIndex
-  }
-
-  function focusThumb(index: number): void {
-    const thumb = thumbRefs()[index]
-    if (!thumb || document.activeElement === thumb) {
-      return
-    }
-
-    suppressNextBlurCommit = true
-    thumb.focus()
-  }
-
-  function moveThumb(index: number, pointerValue: number): void {
-    const nextIndex = applyThumbValue(index, pointerValue)
-
-    if (nextIndex !== undefined && nextIndex !== index) {
-      setActiveThumbIndex(nextIndex)
-      focusThumb(nextIndex)
-    }
-  }
-
-  function onTrackPointerDown(event: PointerEvent): void {
-    if (isActionDisabled() || event.button !== 0) {
-      return
-    }
-
-    const pointerPosition = merged.orientation === 'vertical' ? event.clientY : event.clientX
-    const pointerValue = getValueFromPointer(pointerPosition)
-    const nextActiveThumbIndex = getClosestValueIndex(interactionValues(), pointerValue)
-    startInteraction(nextActiveThumbIndex, event)
-    applyThumbValue(nextActiveThumbIndex, pointerValue)
-  }
-
-  function onTrackPointerMove(event: PointerEvent): void {
-    if (isActionDisabled() || activePointerId !== event.pointerId) {
-      return
-    }
-
-    const target = event.currentTarget as HTMLDivElement
-    if (!target.hasPointerCapture(event.pointerId) || activeThumbIndex === undefined) {
-      return
-    }
-
-    const pointerPosition = merged.orientation === 'vertical' ? event.clientY : event.clientX
-    const delta = pointerPosition - lastPointerPosition
-    if (delta === 0) {
-      return
-    }
-
-    lastPointerPosition = pointerPosition
-
-    moveThumb(activeThumbIndex, getValueFromPointer(pointerPosition))
-  }
-
-  function onTrackPointerUp(event: PointerEvent): void {
-    const target = event.currentTarget as HTMLDivElement
-    finishInteraction(event, target)
-  }
-
-  function onThumbPointerDown(index: number, event: PointerEvent): void {
-    if (isActionDisabled() || event.button !== 0) {
-      return
-    }
-
-    startInteraction(index, event)
-    const target = event.currentTarget as HTMLDivElement
-    if (merged.variant === 'bold') {
-      target.blur()
-      return
-    }
-
-    target.focus()
-  }
-
-  function onThumbPointerMove(event: PointerEvent): void {
-    if (isActionDisabled() || activePointerId !== event.pointerId) {
-      return
-    }
-
-    const target = event.currentTarget as HTMLDivElement
-    if (!target.hasPointerCapture(event.pointerId) || activeThumbIndex === undefined) {
-      return
-    }
-
-    const pointerPosition = merged.orientation === 'vertical' ? event.clientY : event.clientX
-    const delta = pointerPosition - lastPointerPosition
-    if (delta === 0) {
-      return
-    }
-
-    lastPointerPosition = pointerPosition
-
-    moveThumb(activeThumbIndex, getValueFromPointer(pointerPosition))
-  }
-
-  function onThumbPointerUp(event: PointerEvent): void {
-    const target = event.currentTarget as HTMLDivElement
-    finishInteraction(event, target)
-  }
-
-  function onThumbKeyDown(index: number, event: KeyboardEvent): void {
-    if (isActionDisabled()) {
-      return
-    }
-
-    const key = event.key === 'Spacebar' ? ' ' : event.key
-    const isIncrementKey =
-      key === 'ArrowRight' || key === 'ArrowUp' || key === 'Right' || key === 'Up'
-    const isDecrementKey =
-      key === 'ArrowLeft' || key === 'ArrowDown' || key === 'Left' || key === 'Down'
-    const isPageUp = key === 'PageUp'
-    const isPageDown = key === 'PageDown'
-    const isLTR = () =>
-      typeof document === 'undefined'
-        ? true
-        : (document.dir || document.documentElement.dir || 'ltr') !== 'rtl'
-
-    if (
-      !isIncrementKey &&
-      !isDecrementKey &&
-      key !== 'Home' &&
-      key !== 'End' &&
-      !isPageUp &&
-      !isPageDown
-    ) {
-      return
-    }
-
-    event.preventDefault()
-
-    if (key === 'Home') {
-      applyThumbValue(index, getThumbMinValue(interactionValues(), index))
-      return
-    }
-
-    if (key === 'End') {
-      applyThumbValue(index, getThumbMaxValue(interactionValues(), index))
-      return
-    }
-
-    let direction = 0
-    if (isPageUp) {
-      direction = 1
-    } else if (isPageDown) {
-      direction = -1
-    } else if (merged.orientation === 'vertical') {
-      if (key === 'ArrowDown' || key === 'Down') {
-        direction = merged.inverted ? 1 : -1
-      } else if (key === 'ArrowUp' || key === 'Up') {
-        direction = merged.inverted ? -1 : 1
-      } else if (isIncrementKey) {
-        direction = isLTR() ? 1 : -1
-      } else if (isDecrementKey) {
-        direction = isLTR() ? -1 : 1
-      }
-    } else if (isIncrementKey) {
-      direction = isLTR() ? 1 : -1
-    } else if (isDecrementKey) {
-      direction = isLTR() ? -1 : 1
-    }
-
-    const stepSize = isPageUp || isPageDown || event.shiftKey ? pageSize() : keyboardStep()
-
-    const oldValue = interactionValues()[index] ?? merged.min!
-    const candidateValue = oldValue + direction * stepSize
-    applyThumbValue(index, candidateValue)
-    const newValue = interactionValues()[index] ?? merged.min!
-
-    if (!merged.allowThumbCrossing && interactionValues().length > 1 && newValue === oldValue) {
-      const atGlobalBoundary =
-        (direction > 0 && oldValue === merged.max!) || (direction < 0 && oldValue === merged.min!)
-      if (!atGlobalBoundary) {
-        const adjacentIndex = direction > 0 ? index + 1 : index - 1
-        if (adjacentIndex >= 0 && adjacentIndex < interactionValues().length) {
-          focusThumb(adjacentIndex)
-        }
-      }
-    }
-  }
-
-  function onThumbFocus(): void {
-    field.emit('focus')
-  }
-
-  function onThumbKeyUp(event: KeyboardEvent): void {
-    if (isActionDisabled()) {
-      return
-    }
-
-    const key = event.key === 'Spacebar' ? ' ' : event.key
-    const isNavigationKey =
-      key === 'ArrowRight' ||
-      key === 'ArrowUp' ||
-      key === 'ArrowLeft' ||
-      key === 'ArrowDown' ||
-      key === 'Right' ||
-      key === 'Up' ||
-      key === 'Left' ||
-      key === 'Down' ||
-      key === 'Home' ||
-      key === 'End' ||
-      key === 'PageUp' ||
-      key === 'PageDown'
-
-    if (!isNavigationKey || !pendingValues) {
-      return
-    }
-
-    const publicValue = toPublicValue(pendingValues)
-    field.setFormValue(publicValue)
-    merged.onChange?.(publicValue)
-    field.emit('change')
-    pendingValues = undefined
-  }
-
-  function onThumbBlur(): void {
-    field.emit('blur')
-
-    if (suppressNextBlurCommit) {
-      suppressNextBlurCommit = false
-      return
-    }
-
-    if (!pendingValues) {
-      return
-    }
-
-    const publicValue = toPublicValue(pendingValues)
-    field.setFormValue(publicValue)
-    merged.onChange?.(publicValue)
-    field.emit('change')
-    pendingValues = undefined
-  }
-
-  function getValuePercent(value: number): number {
-    const range = merged.max! - merged.min!
-    if (range <= 0) {
-      return 0
-    }
-
-    return (value - merged.min!) / range
-  }
-
-  function getThumbValueText(index: number): string {
-    return String(currentValues()[index] ?? merged.min!)
-  }
-
+  const slider = useSlider(merged)
   return (
     <div
-      id={`${field.id()}-root`}
+      id={`${slider.field.id()}-root`}
       role="group"
       data-slot="root"
       data-orientation={merged.orientation}
-      data-disabled={field.disabled() ? '' : undefined}
-      data-invalid={field.invalid() ? '' : undefined}
+      data-disabled={slider.field.disabled() ? '' : undefined}
+      data-invalid={slider.field.invalid() ? '' : undefined}
       data-readonly={merged.readOnly ? '' : undefined}
       data-required={merged.required ? '' : undefined}
       style={{ ...merged.styles?.root, ...merged.style }}
       class={sliderRootVariants(
         { orientation: merged.orientation },
-        field.disabled() && 'effect-dis',
+        slider.field.disabled() && 'effect-dis',
         merged.classes?.root,
         merged.class,
       )}
     >
       <div
         ref={(element) => {
-          setTrackElementState(element)
+          slider.setTrackElementState(element)
         }}
         data-slot="track"
         data-orientation={merged.orientation}
         style={merged.styles?.track}
         class={sliderTrackVariants(
           {
-            size: field.size(),
+            size: slider.field.size(),
             orientation: merged.orientation,
             variant: merged.variant,
           },
           merged.classes?.track,
         )}
-        onPointerDown={onTrackPointerDown}
-        onPointerMove={onTrackPointerMove}
-        onPointerUp={onTrackPointerUp}
+        onPointerDown={slider.onTrackPointerDown}
+        onPointerMove={slider.onTrackPointerMove}
+        onPointerUp={slider.onTrackPointerUp}
+        onPointerCancel={slider.onPointerCancel}
+        onLostPointerCapture={slider.onPointerCancel}
       >
         <div
           data-slot="range"
           data-orientation={merged.orientation}
           style={{
-            ...rangeStyle(),
+            ...slider.rangeStyle(),
             ...merged.styles?.range,
           }}
           class={sliderRangeVariants(
@@ -711,12 +192,12 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
           )}
         />
 
-        <For each={dividerIndexes()}>
+        <For each={slider.dividerIndexes()}>
           {(dividerIndex) => (
             <div
               data-slot="divider"
               data-orientation={merged.orientation}
-              style={getDividerStyle(dividerIndex)}
+              style={slider.getDividerStyle(dividerIndex)}
               class={sliderDividerVariants(
                 {
                   orientation: merged.orientation,
@@ -729,84 +210,90 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
         </For>
       </div>
 
-      <For each={Array.from({ length: currentValues().length }, (_, index) => index)}>
+      <For each={Array.from({ length: slider.currentValues().length }, (_, index) => index)}>
         {(thumbIndex) => (
           <div
             ref={(element) => {
-              setThumbRefs((previous) => {
+              slider.setThumbRefs((previous) => {
                 const next = [...previous]
                 next[thumbIndex] = element
                 return next
               })
             }}
             data-slot="thumb"
-            data-dragging={dragging() && activeThumbIndexState() === thumbIndex ? '' : undefined}
-            data-disabled={field.disabled() ? '' : undefined}
-            data-invalid={field.invalid() ? '' : undefined}
+            data-dragging={
+              slider.dragging() && slider.activeThumbIndexState() === thumbIndex ? '' : undefined
+            }
+            data-disabled={slider.field.disabled() ? '' : undefined}
+            data-invalid={slider.field.invalid() ? '' : undefined}
             data-readonly={merged.readOnly ? '' : undefined}
             data-required={merged.required ? '' : undefined}
             role="slider"
-            tabIndex={field.disabled() ? undefined : 0}
+            tabIndex={slider.field.disabled() ? undefined : 0}
             style={{
-              ...thumbStyles()[thumbIndex],
+              ...slider.thumbStyles()[thumbIndex],
               ...merged.styles?.thumb,
             }}
             class={sliderThumbVariants(
               {
                 inverted: merged.inverted,
                 orientation: merged.orientation,
-                size: field.size(),
+                size: slider.field.size(),
                 variant: merged.variant,
               },
               merged.classes?.thumb,
             )}
-            aria-valuemin={getThumbMinValue(currentValues(), thumbIndex)}
-            aria-valuenow={currentValues()[thumbIndex] ?? merged.min!}
-            aria-valuemax={getThumbMaxValue(currentValues(), thumbIndex)}
-            aria-valuetext={getThumbValueText(thumbIndex)}
+            aria-valuemin={slider.getThumbMinValue(slider.currentValues(), thumbIndex)}
+            aria-valuenow={slider.currentValues()[thumbIndex] ?? merged.min!}
+            aria-valuemax={slider.getThumbMaxValue(slider.currentValues(), thumbIndex)}
+            aria-valuetext={slider.getThumbValueText(thumbIndex)}
             aria-orientation={merged.orientation}
             aria-label={
-              currentValues().length <= 1
+              slider.currentValues().length <= 1
                 ? 'Thumb'
-                : `Thumb ${thumbIndex + 1} of ${currentValues().length}`
+                : `Thumb ${thumbIndex + 1} of ${slider.currentValues().length}`
             }
             aria-required={merged.required || undefined}
-            aria-disabled={field.disabled() || undefined}
+            aria-disabled={slider.field.disabled() || undefined}
             aria-readonly={merged.readOnly || undefined}
             onPointerDown={(event) => {
-              onThumbPointerDown(thumbIndex, event)
+              slider.onThumbPointerDown(thumbIndex, event)
             }}
             onPointerMove={(event) => {
-              onThumbPointerMove(event)
+              slider.onThumbPointerMove(event)
             }}
             onPointerUp={(event) => {
-              onThumbPointerUp(event)
+              slider.onThumbPointerUp(event)
             }}
+            onPointerCancel={slider.onPointerCancel}
+            onLostPointerCapture={slider.onPointerCancel}
             onKeyDown={(event) => {
-              onThumbKeyDown(thumbIndex, event)
+              slider.onThumbKeyDown(thumbIndex, event)
             }}
-            onKeyUp={onThumbKeyUp}
-            onFocus={onThumbFocus}
-            onBlur={onThumbBlur}
+            onKeyUp={slider.onThumbKeyUp}
+            onFocus={() => {
+              slider.onThumbFocus(thumbIndex)
+            }}
+            onBlur={slider.onThumbBlur}
           >
             <HiddenInput
               type="range"
-              id={field.id() + (thumbIndex === 0 ? '' : `-${thumbIndex + 1}`)}
-              name={field.name()}
-              min={getThumbMinValue(currentValues(), thumbIndex)}
-              max={getThumbMaxValue(currentValues(), thumbIndex)}
-              step={definedStep() ?? 'any'}
-              value={currentValues()[thumbIndex] ?? merged.min!}
+              id={slider.field.id() + (thumbIndex === 0 ? '' : `-${thumbIndex + 1}`)}
+              name={slider.field.name()}
+              min={slider.getThumbMinValue(slider.currentValues(), thumbIndex)}
+              max={slider.getThumbMaxValue(slider.currentValues(), thumbIndex)}
+              step={slider.definedStep() ?? 'any'}
+              value={slider.currentValues()[thumbIndex] ?? merged.min!}
               required={merged.required}
-              disabled={field.disabled()}
+              disabled={slider.field.disabled()}
               readOnly={merged.readOnly}
-              tabIndex={field.disabled() ? undefined : -1}
-              aria-valuetext={getThumbValueText(thumbIndex)}
+              tabIndex={slider.field.disabled() ? undefined : -1}
+              aria-valuetext={slider.getThumbValueText(thumbIndex)}
               aria-orientation={merged.orientation}
               aria-required={merged.required || undefined}
-              aria-disabled={field.disabled() || undefined}
+              aria-disabled={slider.field.disabled() || undefined}
               aria-readonly={merged.readOnly || undefined}
-              {...field.ariaAttrs()}
+              {...slider.field.ariaAttrs()}
             />
           </div>
         )}

--- a/src/forms/slider/slider.tsx
+++ b/src/forms/slider/slider.tsx
@@ -150,16 +150,14 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
       defaultSize: 'md',
     }),
   )
-  const sliderOptions = mergeProps(merged, {
-    get disabled() {
-      return field.disabled()
-    },
-    onValueInput(value: TValue) {
+  const slider = useSlider(merged, {
+    disabled: field.disabled,
+    onValueInput(value) {
       field.setFormValue(value)
       merged.onValueChange?.(value)
       field.emit('input')
     },
-    onValueCommit(value: TValue) {
+    onValueCommit(value) {
       field.setFormValue(value)
       merged.onChange?.(value)
       field.emit('change')
@@ -171,7 +169,6 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
       field.emit('blur')
     },
   })
-  const slider = useSlider(sliderOptions)
 
   onMount(() => {
     if (field.value() === undefined) {
@@ -199,7 +196,7 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
     >
       <div
         ref={(element) => {
-          slider.setTrackElementState(element)
+          slider.setTrackRef(element)
         }}
         data-slot="track"
         data-orientation={merged.orientation}
@@ -286,9 +283,9 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
               },
               merged.classes?.thumb,
             )}
-            aria-valuemin={slider.getThumbMinValue(slider.currentValues(), thumbIndex)}
+            aria-valuemin={slider.getThumbMinValue(thumbIndex)}
             aria-valuenow={slider.currentValues()[thumbIndex] ?? merged.min!}
-            aria-valuemax={slider.getThumbMaxValue(slider.currentValues(), thumbIndex)}
+            aria-valuemax={slider.getThumbMaxValue(thumbIndex)}
             aria-valuetext={slider.getThumbValueText(thumbIndex)}
             aria-orientation={merged.orientation}
             aria-label={
@@ -323,8 +320,8 @@ export function Slider<TValue extends SliderT.Value = SliderT.Value>(
               type="range"
               id={field.id() + (thumbIndex === 0 ? '' : `-${thumbIndex + 1}`)}
               name={field.name()}
-              min={slider.getThumbMinValue(slider.currentValues(), thumbIndex)}
-              max={slider.getThumbMaxValue(slider.currentValues(), thumbIndex)}
+              min={slider.getThumbMinValue(thumbIndex)}
+              max={slider.getThumbMaxValue(thumbIndex)}
               step={slider.definedStep() ?? 'any'}
               value={slider.currentValues()[thumbIndex] ?? merged.min!}
               required={merged.required}

--- a/todo.md
+++ b/todo.md
@@ -13,7 +13,7 @@
 - [x] only add data attributes on essential elements in `checkbox`, unwrap `dataAttr` memo
 - [x] simplify `radio-group` 's classes, remove unnecessary wrapper elements, let form-field component to control form title & description, and make it more semantic and accessible.
 - [x] keep tooltip panel open and add move transition when hover on another trigger which also has a tooltip, to have better user experience when switching between triggers.
-- [ ] extract logic from slider component to a separate hook, and export component level hooks (should located at same dir 's `/hook` dir ) custom implementations.
+- [x] extract logic from slider component to a separate hook, and export component level hooks (should located at same dir 's `/hook` dir ) custom implementations.
 - [ ] unify custom render function prop with prefix `render`, target should be `renderXXXX`
 - [ ] unify and correct class/style priority: top level `class` / `style` (root only) > `classes` / `styles` > component builtin classes / styles
 - [ ] refactor form / form-field to formisch, replace existing form context logic if possible


### PR DESCRIPTION
### Motivation

- Separate the internal slider logic from the render layer so it can be reused and better tested by extracting behavior into a reusable `useSlider` hook. 
- Simplify the `Slider` component to be purely presentational and delegate state, event handling and calculations to the hook. 

### Description

- Added a new hook at `src/forms/slider/hook/use-slider.ts` and re-exported it from `src/forms/slider/hook/index.ts` and `src/forms/slider/index.ts`. 
- Refactored `src/forms/slider/slider.tsx` to consume `useSlider(merged)` and replace in-component logic with hook accessors and handlers, including wiring `onPointerCancel`/`onLostPointerCapture` on track and thumbs. 
- Updated `HiddenInput` attributes and thumb props to use values from the hook (e.g. `field`, `currentValues`, `definedStep`, `getThumbMinValue`, `getThumbMaxValue`, etc.).
- Added two tests in `src/forms/slider/slider.test.tsx` to cover overlapping-thumb track presses (reusing last-focused thumb) and pointer cancel committing pending drag values.
- Marked the todo item for extracting slider logic as complete in `todo.md`.

### Testing

- Ran the unit test suite (via `vitest`) including the `Slider` tests; new tests `track press reuses the last focused overlapping thumb` and `pointer cancel commits pending drag values` were added and executed successfully. 
- Component build and type-check were validated locally and completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4709ce9a108330b2967b8f39eb13c7)