### PR TITLE
Enhance menu keyboard behavior

### DIFF
--- a/src/overlays/context-menu/context-menu.test.tsx
+++ b/src/overlays/context-menu/context-menu.test.tsx
@@ -82,6 +82,35 @@ describe('ContextMenu', () => {
     expect(onSelect).toHaveBeenCalledTimes(1)
   })
 
+  test('opens from keyboard context menu shortcut at trigger center', async () => {
+    const screen = render(() => (
+      <ContextMenu items={[{ label: 'Keyboard action' }, { label: 'Second action' }]}>
+        <button type="button">Row Item</button>
+      </ContextMenu>
+    ))
+
+    const trigger = screen.getByText('Row Item').closest('[data-slot="trigger"]') as HTMLElement
+    trigger.getBoundingClientRect = () =>
+      ({
+        bottom: 40,
+        height: 20,
+        left: 10,
+        right: 110,
+        top: 20,
+        width: 100,
+        x: 10,
+        y: 20,
+        toJSON: () => ({}),
+      }) as DOMRect
+
+    await fireEvent.keyDown(screen.getByText('Row Item'), { key: 'F10', shiftKey: true })
+
+    await waitFor(() => {
+      const highlighted = document.body.querySelector('[data-slot="item"][data-highlighted]')
+      expect(highlighted?.textContent).toContain('Keyboard action')
+    })
+  })
+
   test('exposes trigger data state while opened, closed, and disabled', async () => {
     const screen = render(() => (
       <ContextMenu disabled items={[{ label: 'Disabled action' }]}>

--- a/src/overlays/context-menu/context-menu.tsx
+++ b/src/overlays/context-menu/context-menu.tsx
@@ -63,6 +63,10 @@ function hasLongPressMovedBeyondTolerance(
   return x * x + y * y > CONTEXT_MENU_LONG_PRESS_MOVE_TOLERANCE ** 2
 }
 
+function isContextMenuKeyboardEvent(event: KeyboardEvent): boolean {
+  return event.key === 'ContextMenu' || (event.key === 'F10' && event.shiftKey)
+}
+
 /**
  * Menu triggered by right-click or long press on its child content.
  */
@@ -103,14 +107,29 @@ export function ContextMenu(props: ContextMenuProps): JSX.Element {
     merged.onOpenChange?.(open)
   }
 
-  const openFromPoint = (x: number, y: number): void => {
+  const openFromPoint = (
+    x: number,
+    y: number,
+    strategy: OverlayMenuFocusStrategy = 'content',
+  ): void => {
     if (merged.disabled) {
       return
     }
 
-    setAutoFocusStrategy('content')
+    setAutoFocusStrategy(strategy)
     setAnchorPoint({ x, y })
     commitOpen(true)
+  }
+
+  const openFromTriggerCenter = (strategy: OverlayMenuFocusStrategy): void => {
+    const rect = triggerElement?.getBoundingClientRect()
+
+    if (!rect) {
+      openFromPoint(0, 0, strategy)
+      return
+    }
+
+    openFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2, strategy)
   }
 
   /** Consume the deferred native contextmenu event emitted after dismissing from right-click or long-press input. */
@@ -335,6 +354,21 @@ export function ContextMenu(props: ContextMenuProps): JSX.Element {
         onPointerMove={onPointerMove}
         onPointerCancel={onPointerCancel}
         onPointerUp={onPointerUp}
+        onKeyDown={(event) => {
+          if (event.defaultPrevented || merged.disabled || !isContextMenuKeyboardEvent(event)) {
+            return
+          }
+
+          event.preventDefault()
+          event.stopPropagation()
+
+          if (resolvedOpen()) {
+            commitOpen(false)
+            return
+          }
+
+          openFromTriggerCenter('first')
+        }}
       >
         {merged.children}
       </span>

--- a/src/overlays/dropdown-menu/dropdown-menu.test.tsx
+++ b/src/overlays/dropdown-menu/dropdown-menu.test.tsx
@@ -53,6 +53,28 @@ describe('DropdownMenu', () => {
     expect(onSelect).toHaveBeenCalledTimes(1)
   })
 
+  test('closes from trigger keyboard escape while open', async () => {
+    const screen = render(() => (
+      <DropdownMenu items={[{ label: 'Open file' }]}>
+        <button type="button">Actions</button>
+      </DropdownMenu>
+    ))
+
+    const trigger = screen.getByText('Actions')
+    await fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+
+    await waitFor(() => {
+      expect(document.body.querySelector('[data-slot="content"]')).not.toBeNull()
+    })
+
+    await fireEvent.keyDown(trigger, { key: 'Escape' })
+
+    await waitFor(() => {
+      expect(document.body.querySelector('[data-slot="content"][data-expanded]')).toBeNull()
+      expect(document.body.querySelector('[data-slot="content"][data-closed]')).not.toBeNull()
+    })
+  })
+
   test('focuses content on click open, supports typeahead, and restores trigger focus on escape', async () => {
     const screen = render(() => (
       <DropdownMenu items={[{ label: 'Archive' }, { label: 'Duplicate' }, { label: 'Delete' }]}>

--- a/src/overlays/dropdown-menu/dropdown-menu.tsx
+++ b/src/overlays/dropdown-menu/dropdown-menu.tsx
@@ -126,6 +126,12 @@ export function DropdownMenu(props: DropdownMenuProps): JSX.Element {
             return
           }
 
+          if (event.key === 'Escape' && isOpen()) {
+            event.preventDefault()
+            commitOpen(false)
+            return
+          }
+
           if (event.key === 'ArrowDown') {
             event.preventDefault()
             openWithStrategy('first')


### PR DESCRIPTION
### Motivation
- Improve keyboard accessibility and parity with common UI patterns (e.g. MUI/base) for context and dropdown menus.  
- Allow users to dismiss an open dropdown from the trigger via `Escape` when navigating by keyboard.  
- Support keyboard invocation of context menus (ContextMenu key and Shift+F10) anchored to the trigger for discoverable keyboard workflows.

### Description
- Added trigger-side `Escape` handling to `DropdownMenu` so the open menu is dismissed when `Escape` is pressed on the trigger (`src/overlays/dropdown-menu/dropdown-menu.tsx`).
- Added recognition of context-menu keyboard events and `openFromTriggerCenter` logic to `ContextMenu`, anchoring keyboard-invoked context menus to the trigger center and using a `first` autofocus strategy (`src/overlays/context-menu/context-menu.tsx`).
- Added unit tests covering the new behaviors: `closes from trigger keyboard escape while open` in `dropdown-menu.test.tsx` and `opens from keyboard context menu shortcut at trigger center` in `context-menu.test.tsx` (`src/overlays/.../*.test.tsx`).
- Minor test and utility wiring so focus and open strategies are propagated correctly when opening from keyboard.

### Testing
- Ran targeted tests with `bun run test src/overlays/dropdown-menu/dropdown-menu.test.tsx src/overlays/context-menu/context-menu.test.tsx` and observed all tests passing.  
- Ran full QA checks with `bun run qa` (lint/format/typecheck) which completed successfully.  
- All automated tests executed in this rollout passed (`53` tests across the affected suites passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47159597ec8330ae041487119c9fe2)