### PR TITLE
docs: use design-system Button/Icon/ListBox, add markdown copy action, and align expressive-code deps

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "cls-variant": "^1.2.0",
       },
       "devDependencies": {
-        "@expressive-code/plugin-line-numbers": "^0.44.0",
+        "@expressive-code/plugin-line-numbers": "^0.42.0",
         "@iconify-json/lucide": "^1.2.117",
         "@iconify/tailwind": "1.2.0",
         "@rolldown/pluginutils": "*",
@@ -144,13 +144,13 @@
 
     "@exodus/bytes": ["@exodus/bytes@1.15.1", "https://registry.npmmirror.com/@exodus/bytes/-/bytes-1.15.1.tgz", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
 
-    "@expressive-code/core": ["@expressive-code/core@0.44.0", "https://registry.npmmirror.com/@expressive-code/core/-/core-0.44.0.tgz", { "dependencies": { "@ctrl/tinycolor": "^4.0.4", "hast-util-select": "^6.0.2", "hast-util-to-html": "^9.0.1", "hast-util-to-text": "^4.0.1", "hastscript": "^9.0.0", "postcss": "^8.4.38", "postcss-nested": "^6.0.1", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.1" } }, "sha512-xgiF2P6tYUbrhi3+x0S8xHZWT1t3Bvb3U91tAtRbLb9HLejLvYc5GZUqKICKLaUN4iSGhhNJu2fM/aH8e5yCMg=="],
+    "@expressive-code/core": ["@expressive-code/core@0.42.0", "https://registry.npmmirror.com/@expressive-code/core/-/core-0.42.0.tgz", { "dependencies": { "@ctrl/tinycolor": "^4.0.4", "hast-util-select": "^6.0.2", "hast-util-to-html": "^9.0.1", "hast-util-to-text": "^4.0.1", "hastscript": "^9.0.0", "postcss": "^8.4.38", "postcss-nested": "^6.0.1", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.1" } }, "sha512-MN11+9nfmaC7sYu2BZJXAXqwkBRt8t1xTSqP+Ti1NfTEskgl6xUnzDxoaiQkg0BMzpglA0pys4dpDKquP/cyIw=="],
 
     "@expressive-code/plugin-frames": ["@expressive-code/plugin-frames@0.42.0", "https://registry.npmmirror.com/@expressive-code/plugin-frames/-/plugin-frames-0.42.0.tgz", { "dependencies": { "@expressive-code/core": "^0.42.0" } }, "sha512-XtkPm+941Uta7Y+81Acv+OA/20F1NJmJhCX6UYGKpqEIGqplNh3PTOhcURp6tcruhlzJcWcvpWy6Oigz3SrjqA=="],
 
     "@expressive-code/plugin-frames/@expressive-code/core": ["@expressive-code/core@0.42.0", "https://registry.npmmirror.com/@expressive-code/core/-/core-0.42.0.tgz", { "dependencies": { "@ctrl/tinycolor": "^4.0.4", "hast-util-select": "^6.0.2", "hast-util-to-html": "^9.0.1", "hast-util-to-text": "^4.0.1", "hastscript": "^9.0.0", "postcss": "^8.4.38", "postcss-nested": "^6.0.1", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.1" } }, "sha512-MN11+9nfmaC7sYu2BZJXAXqwkBRt8t1xTSqP+Ti1NfTEskgl6xUnzDxoaiQkg0BMzpglA0pys4dpDKquP/cyIw=="],
 
-    "@expressive-code/plugin-line-numbers": ["@expressive-code/plugin-line-numbers@0.44.0", "https://registry.npmmirror.com/@expressive-code/plugin-line-numbers/-/plugin-line-numbers-0.44.0.tgz", { "dependencies": { "@expressive-code/core": "^0.44.0" } }, "sha512-jZbCinT19JTZ1TCl18vGZBAgbNcegkWQjsuvqEDN2OeAlCqcSFE62j9d70+fk2zUd8nHnEgXF214D3a+STsrAQ=="],
+    "@expressive-code/plugin-line-numbers": ["@expressive-code/plugin-line-numbers@0.42.0", "https://registry.npmmirror.com/@expressive-code/plugin-line-numbers/-/plugin-line-numbers-0.42.0.tgz", { "dependencies": { "@expressive-code/core": "^0.42.0" } }, "sha512-xY0s/b8UTF8fGrHWbJ8uX95yCDU1NpepXOTtcLBJobQV08RA7G+hzxL0BtDRso7RK4bCrJHio+BgYzI/M21BBA=="],
 
     "@expressive-code/plugin-shiki": ["@expressive-code/plugin-shiki@0.42.0", "https://registry.npmmirror.com/@expressive-code/plugin-shiki/-/plugin-shiki-0.42.0.tgz", { "dependencies": { "@expressive-code/core": "^0.42.0", "shiki": "^4.0.2" } }, "sha512-PMKey/kLmewttAHQezL+Y5Fx3vVssfDi3+FJOYQQS2mXP3tQspFELtKKAfsXfmSXdToZYgwoO69HJndqfE+09g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -150,7 +150,7 @@
 
     "@expressive-code/plugin-frames/@expressive-code/core": ["@expressive-code/core@0.42.0", "https://registry.npmmirror.com/@expressive-code/core/-/core-0.42.0.tgz", { "dependencies": { "@ctrl/tinycolor": "^4.0.4", "hast-util-select": "^6.0.2", "hast-util-to-html": "^9.0.1", "hast-util-to-text": "^4.0.1", "hastscript": "^9.0.0", "postcss": "^8.4.38", "postcss-nested": "^6.0.1", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.1" } }, "sha512-MN11+9nfmaC7sYu2BZJXAXqwkBRt8t1xTSqP+Ti1NfTEskgl6xUnzDxoaiQkg0BMzpglA0pys4dpDKquP/cyIw=="],
 
-    "@expressive-code/plugin-line-numbers": ["@expressive-code/plugin-line-numbers@0.42.0", "https://registry.npmmirror.com/@expressive-code/plugin-line-numbers/-/plugin-line-numbers-0.42.0.tgz", { "dependencies": { "@expressive-code/core": "^0.42.0" } }, "sha512-xY0s/b8UTF8fGrHWbJ8uX95yCDU1NpepXOTtcLBJobQV08RA7G+hzxL0BtDRso7RK4bCrJHio+BgYzI/M21BBA=="],
+    "@expressive-code/plugin-line-numbers": ["@expressive-code/plugin-line-numbers@0.42.0", "https://registry.npmjs.org/@expressive-code/plugin-line-numbers/-/plugin-line-numbers-0.42.0.tgz", { "dependencies": { "@expressive-code/core": "^0.42.0" } }, "sha512-xY0s/b8UTF8fGrHWbJ8uX95yCDU1NpepXOTtcLBJobQV08RA7G+hzxL0BtDRso7RK4bCrJHio+BgYzI/M21BBA=="],
 
     "@expressive-code/plugin-shiki": ["@expressive-code/plugin-shiki@0.42.0", "https://registry.npmmirror.com/@expressive-code/plugin-shiki/-/plugin-shiki-0.42.0.tgz", { "dependencies": { "@expressive-code/core": "^0.42.0", "shiki": "^4.0.2" } }, "sha512-PMKey/kLmewttAHQezL+Y5Fx3vVssfDi3+FJOYQQS2mXP3tQspFELtKKAfsXfmSXdToZYgwoO69HJndqfE+09g=="],
 

--- a/docs/build/markdown/page.ts
+++ b/docs/build/markdown/page.ts
@@ -111,7 +111,7 @@ ${examples.map((example, index) => `  ${JSON.stringify(example.path)}: __DocsExa
     '',
     'export default function MarkdownPage() {',
     `  return Markdown({ pageKey: ${JSON.stringify(page.pageKey)}, frontmatter, apiDoc, onThisPageEntries: ` +
-      `${JSON.stringify(onThisPageEntries)}, Content: MDXContent, examples, codeTabs })`,
+      `${JSON.stringify(onThisPageEntries)}, Content: MDXContent, examples, codeTabs, markdownSource: ${JSON.stringify(markdownSource)} })`,
     '}',
     '',
   ].join('\n')

--- a/docs/components/content-header.tsx
+++ b/docs/components/content-header.tsx
@@ -1,7 +1,6 @@
 import type { Accessor, JSX } from 'solid-js'
 
-import { Switch, cn } from '../../src'
-import { buttonVariants } from '../../src/elements/button/button.class'
+import { Button, Icon, Switch, cn } from '../../src'
 
 export interface ContentHeaderProps {
   pageTitle: Accessor<string>
@@ -43,15 +42,17 @@ export function ContentHeader(props: ContentHeaderProps) {
           checkedIcon="i-lucide-moon"
           uncheckedIcon="i-lucide-sun"
         />
-        <a
+        <Button
+          as="a"
           href="https://github.com/subframe7536/moraine"
           target="_blank"
           rel="noopener noreferrer"
-          class={buttonVariants({ variant: 'ghost', size: 'icon-sm' })}
+          variant="ghost"
+          size="icon-sm"
           aria-label="GitHub repository"
         >
-          <span class="i-lucide-github block" />
-        </a>
+          <Icon name="i-lucide-github" />
+        </Button>
       </div>
     </header>
   )

--- a/docs/components/docs-code-block.class.ts
+++ b/docs/components/docs-code-block.class.ts
@@ -1,4 +1,5 @@
-export const DOCS_CODE_BLOCK_ROOT_CLASS = '[&_.expressive-code_.copy_button]:rounded-md!'
+export const DOCS_CODE_BLOCK_ROOT_CLASS =
+  '[&_.expressive-code_.copy_button]:rounded-md! [&_.expressive-code:has(pre_code>span:only-child)_.copy_button]:top-1/2! [&_.expressive-code:has(pre_code>span:only-child)_.copy_button]:-translate-y-1/2!'
 
 export const DOCS_CODE_BLOCK_SOURCE_CLASS =
   'group relative my-0 border-t border-border/80 overflow-hidden'

--- a/docs/components/docs-command-palette.tsx
+++ b/docs/components/docs-command-palette.tsx
@@ -1,7 +1,7 @@
 import type { Accessor, JSX } from 'solid-js'
 import { Show, createMemo, createSignal, onCleanup, onMount } from 'solid-js'
 
-import { CommandPalette, KbdGroup, cn } from '../../src'
+import { Button, CommandPalette, Icon, KbdGroup, cn } from '../../src'
 import type { CommandPaletteT } from '../../src'
 
 import type { SidebarPage } from './sidebar'
@@ -62,18 +62,19 @@ export function DocsSearchTrigger(props: {
   const variant = () => props.variant ?? 'desktop'
 
   return (
-    <button
-      type="button"
+    <Button
       aria-label="Open search"
       onClick={() => props.onOpen()}
+      variant="ghost"
+      size={variant() === 'mobile' ? 'icon-sm' : 'sm'}
       class={cn(
         variant() === 'mobile'
-          ? 'text-muted-foreground p-2 rounded-md inline-flex h-9 w-9 cursor-pointer items-center justify-center hover:(text-foreground bg-accent/50)'
-          : 'text-sm text-muted-foreground px-3 py-1.5 b-1 b-border rounded-md bg-background/70 flex flex-1 gap-2 h-9 max-w-xs cursor-pointer transition-colors items-center hover:(border-border bg-background)',
+          ? 'text-muted-foreground hover:(text-foreground bg-accent/50)'
+          : 'text-sm text-muted-foreground px-3 b-1 b-border bg-background/70 flex-1 gap-2 max-w-xs justify-start hover:(border-border bg-background)',
         props.class,
       )}
     >
-      <span class="i-lucide-search shrink-0 size-4 block" aria-hidden="true" />
+      <Icon name="i-lucide-search" class="shrink-0 size-4" />
       <Show when={variant() === 'desktop'}>
         <span class="text-left flex-1 truncate">Search...</span>
         <KbdGroup
@@ -83,7 +84,7 @@ export function DocsSearchTrigger(props: {
           // classes={{ item: 'text-[0.65rem]' }}
         />
       </Show>
-    </button>
+    </Button>
   )
 }
 

--- a/docs/components/docs-page-navigation.tsx
+++ b/docs/components/docs-page-navigation.tsx
@@ -1,6 +1,6 @@
 import { Show, createMemo } from 'solid-js'
 
-import { cn } from '../../src'
+import { Button, Icon, cn } from '../../src'
 
 import { getAdjacentDocsPages } from './docs-page-navigation.utils'
 import { getDocsPages } from './docs-route'
@@ -14,19 +14,21 @@ function NavigationCard(props: {
   const isNext = () => props.direction === 'next'
 
   return (
-    <a
+    <Button
+      as="a"
       href={props.page.path}
       aria-label={`${isNext() ? 'Next' : 'Previous'} page: ${props.page.label}`}
+      variant="outline"
       class={cn(
-        'group px-4 py-3.5 border border-border rounded-lg bg-background flex gap-3 min-h-20 w-full transition-([background-color,border-color,transform] duration-180 ease-out) items-center focus-visible:(outline-none ring-2 ring-ring ring-offset-2 ring-offset-background) hover:(border-primary/40 bg-accent/35) active:translate-y-px',
+        'group px-4 py-3.5 rounded-lg bg-background gap-3 h-auto min-h-20 w-full transition-([background-color,border-color,transform] duration-180 ease-out) hover:(border-primary/40 bg-accent/35) active:translate-y-px',
         isNext() ? 'text-right justify-end' : 'text-left',
         props.class,
       )}
     >
       <Show when={!isNext()}>
-        <span
-          class="i-lucide-arrow-left text-muted-foreground shrink-0 size-4 transition-transform duration-180 ease-out group-hover:-translate-x-0.5"
-          aria-hidden="true"
+        <Icon
+          name="i-lucide-arrow-left"
+          class="text-muted-foreground shrink-0 size-4 transition-transform duration-180 ease-out group-hover:-translate-x-0.5"
         />
       </Show>
       <span class="min-w-0">
@@ -36,12 +38,12 @@ function NavigationCard(props: {
         </span>
       </span>
       <Show when={isNext()}>
-        <span
-          class="i-lucide-arrow-right text-muted-foreground shrink-0 size-4 transition-transform duration-180 ease-out group-hover:translate-x-0.5"
-          aria-hidden="true"
+        <Icon
+          name="i-lucide-arrow-right"
+          class="text-muted-foreground shrink-0 size-4 transition-transform duration-180 ease-out group-hover:translate-x-0.5"
         />
       </Show>
-    </a>
+    </Button>
   )
 }
 

--- a/docs/components/markdown.test.tsx
+++ b/docs/components/markdown.test.tsx
@@ -1,5 +1,5 @@
 // oxlint-disable class-methods-use-this
-import { render } from '@solidjs/testing-library'
+import { fireEvent, render } from '@solidjs/testing-library'
 import type { Component, JSX } from 'solid-js'
 import { describe, expect, test, vi } from 'vitest'
 
@@ -70,6 +70,7 @@ describe('Markdown', () => {
         Content={EmptyContent}
         examples={{}}
         codeTabs={{}}
+        markdownSource="# Button docs"
       />
     ))
 
@@ -84,6 +85,31 @@ describe('Markdown', () => {
     expect(markdownLink.getAttribute('href')).toBe('/button.md')
     expect(markdownLink.getAttribute('rel')).toBe('alternate external')
     expect(markdownLink.getAttribute('type')).toBe('text/markdown')
+    expect(markdownLink.className).toBe(screen.getByText('Source Code').closest('a')?.className)
+    expect(screen.getByRole('button', { name: 'Copy markdown source' })).toBeDefined()
+  })
+
+  test('copies markdown source from the header action', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('navigator', { clipboard: { writeText } })
+
+    const screen = render(() => (
+      <Markdown
+        pageKey="button"
+        frontmatter={FRONTMATTER}
+        Content={EmptyContent}
+        examples={{}}
+        codeTabs={{}}
+        markdownSource="# Button docs"
+      />
+    ))
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Copy markdown source' }))
+
+    expect(writeText).toHaveBeenCalledWith('# Button docs')
+    expect(screen.getByText('Copied Markdown')).toBeDefined()
+
+    vi.unstubAllGlobals()
   })
 
   test('renders api reference from api doc automatically', () => {

--- a/docs/components/markdown.tsx
+++ b/docs/components/markdown.tsx
@@ -1,5 +1,5 @@
 import type { Component } from 'solid-js'
-import { createMemo, Show } from 'solid-js'
+import { createMemo, createSignal, Show } from 'solid-js'
 import { Dynamic } from 'solid-js/web'
 
 import { Button } from '../../src'
@@ -70,6 +70,7 @@ export interface RenderExampleMarkdownPageInput {
   Content: Component<DocsMdxContentProps>
   examples: Record<string, DocsMdxExample>
   codeTabs: Record<string, DocsMdxCodeTabItem[]>
+  markdownSource?: string
 }
 
 export function Markdown(input: RenderExampleMarkdownPageInput) {
@@ -81,6 +82,24 @@ export function Markdown(input: RenderExampleMarkdownPageInput) {
     const sourcePath = component()?.sourcePath
     return sourcePath ? `${GITHUB_SOURCE_BASE_URL}/${sourcePath}` : undefined
   }
+  const [copyState, setCopyState] = createSignal<'idle' | 'copied' | 'failed'>('idle')
+
+  const copyMarkdownSource = async () => {
+    const markdownSource = input.markdownSource
+    if (!markdownSource) {
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(markdownSource)
+      setCopyState('copied')
+      window.setTimeout(() => setCopyState('idle'), 1600)
+    } catch {
+      setCopyState('failed')
+      window.setTimeout(() => setCopyState('idle'), 1600)
+    }
+  }
+
   const onThisPageEntries = createMemo(() => [
     ...(input.onThisPageEntries ?? []),
     ...getDocsApiReferenceTocEntries(input.apiDoc),
@@ -113,7 +132,7 @@ export function Markdown(input: RenderExampleMarkdownPageInput) {
             </p>
 
             <div class="text-xs mt-3 flex flex-wrap gap-3 items-center">
-              <Show when={input.pageKey !== 'introduction'}>
+              <Show when={input.pageKey !== 'introduction' && input.markdownSource}>
                 <Button
                   as="a"
                   href={`/${input.pageKey}.md`}
@@ -121,10 +140,22 @@ export function Markdown(input: RenderExampleMarkdownPageInput) {
                   rel="alternate external"
                   type="text/markdown"
                   variant="outline"
-                  size="sm"
                   leading="i-lucide:file-text"
                 >
                   View as Markdown
+                </Button>
+                <Button
+                  aria-label="Copy markdown source"
+                  variant="outline"
+                  leading={copyState() === 'copied' ? 'i-lucide:check' : 'i-lucide:copy'}
+                  disabled={!input.markdownSource}
+                  onClick={copyMarkdownSource}
+                >
+                  {copyState() === 'copied'
+                    ? 'Copied Markdown'
+                    : copyState() === 'failed'
+                      ? 'Copy Failed'
+                      : 'Copy as Markdown'}
                 </Button>
               </Show>
               <Show when={githubSourceHref()}>

--- a/docs/components/mdx-components.class.ts
+++ b/docs/components/mdx-components.class.ts
@@ -2,11 +2,11 @@ export const DOCS_INSTALL_TABS_ROOT_CLASS =
   'my-3 gap-0 border border-border rounded-lg bg-card overflow-hidden'
 
 export const DOCS_INSTALL_TABS_LIST_CLASS =
-  'p-1.5 px-2 w-full justify-start rounded-none border-b border-border bg-muted/60'
+  'p-1.5 w-full justify-start rounded-none border-b border-border bg-muted/60 overflow-x-auto'
 
-export const DOCS_INSTALL_TABS_INDICATOR_CLASS = 'hidden'
+export const DOCS_INSTALL_TABS_INDICATOR_CLASS = 'border border-border bg-background shadow-xs'
 
 export const DOCS_INSTALL_TABS_TRIGGER_CLASS =
-  'text-sm px-2.5 py-1 flex-none rounded-md text-muted-foreground data-selected:(bg-background text-foreground shadow-xs) hover:not-disabled:text-foreground active:not-disabled:scale-[0.97] transition-[color,background-color,transform] duration-150'
+  'text-sm px-2.5 py-1 flex-none z-1 rounded-md text-muted-foreground data-selected:text-foreground hover:not-disabled:text-foreground active:not-disabled:scale-[0.97] transition-[color,transform] duration-150'
 
 export const DOCS_INSTALL_TABS_CONTENT_CLASS = 'p-0'

--- a/docs/components/mdx-components.test.tsx
+++ b/docs/components/mdx-components.test.tsx
@@ -107,6 +107,8 @@ describe('createDocsMdxComponents', () => {
     expect(
       screen.getByRole('tabpanel').querySelector('[data-code-variant="install"]'),
     ).not.toBeNull()
-    expect(screen.container.querySelector('[data-slot="indicator"]')?.className).toContain('hidden')
+    expect(screen.container.querySelector('[data-slot="indicator"]')?.className).toContain(
+      'bg-background',
+    )
   })
 })

--- a/docs/components/sidebar.test.tsx
+++ b/docs/components/sidebar.test.tsx
@@ -49,8 +49,8 @@ describe('Sidebar', () => {
       />
     ))
 
-    const rowButton = screen.getByText('Sidebar Frame').closest('button') as HTMLButtonElement
-    await fireEvent.click(rowButton)
+    const row = screen.getByRole('option', { name: /Sidebar Frame/ })
+    await fireEvent.click(row)
 
     expect(setActivePage).toHaveBeenCalledWith('sidebar-frame')
   })

--- a/docs/components/sidebar.tsx
+++ b/docs/components/sidebar.tsx
@@ -97,7 +97,7 @@ export const Sidebar = (props: SidebarProps) => {
             content: 'gap-0',
             label:
               'text-[0.68rem] text-muted-foreground tracking-[0.14em] font-semibold mb-1.5 mt-3 px-2 uppercase',
-            item: 'text-sm text-muted-foreground px-2.5 py-1.75 min-h-0 rounded-md transition-([background-color,color] duration-150 ease-out) data-highlighted:(text-muted-foreground bg-transparent) data-selected:(text-accent-foreground font-medium bg-accent) hover:(text-foreground bg-accent/30)',
+            item: 'text-sm text-muted-foreground px-2.5 py-1.75 min-h-0 rounded-md transition-colors duration-100 data-selected:(text-accent-foreground font-medium bg-accent) hover:(text-foreground bg-accent/30)',
             itemWrapper: 'min-w-0',
             itemLabel: 'truncate',
           }}

--- a/docs/components/sidebar.tsx
+++ b/docs/components/sidebar.tsx
@@ -1,8 +1,9 @@
 import type { Accessor } from 'solid-js'
-import { For, Show, createMemo } from 'solid-js'
+import { Show, createMemo } from 'solid-js'
 
 import { version } from '../../package.json'
-import { Badge, Button, cn } from '../../src'
+import { Badge, Button, ListBox, cn } from '../../src'
+import type { ListBoxT } from '../../src'
 
 import type { DocsPageEntry } from './docs-route'
 
@@ -47,48 +48,60 @@ export const Sidebar = (props: SidebarProps) => {
     ]
   })
 
+  const items = createMemo<ListBoxT.Entry[]>(() => {
+    const entries: ListBoxT.Entry[] = []
+
+    for (const section of grouped()) {
+      if (section.group) {
+        entries.push({
+          type: 'label',
+          key: `group-${section.group}`,
+          label: section.group,
+        })
+      }
+
+      for (const page of section.pages) {
+        entries.push({
+          value: page.key,
+          label: page.label,
+          trailingRender: () => (
+            <Show when={page.badge}>
+              {(badge) => (
+                <span class="text-[0.6rem] leading-none font-semibold px-1.25 py-0.75 border rounded-sm bg-background/70 shrink-0 uppercase">
+                  {badge()}
+                </span>
+              )}
+            </Show>
+          ),
+        })
+      }
+    }
+
+    return entries
+  })
+
   return (
     <div class="px-3 pb-10 pt-3 h-full min-h-0 overflow-y-auto">
       <nav class="pb-2 flex flex-col gap-5">
-        <For each={grouped()}>
-          {(section) => (
-            <section>
-              <Show when={section.group}>
-                <div class="text-[0.68rem] text-muted-foreground tracking-[0.14em] font-semibold mb-1.5 mt-3 px-2 uppercase">
-                  {section.group}
-                </div>
-              </Show>
-
-              <div class="flex flex-col gap-0.5">
-                <For each={section.pages}>
-                  {(page) => (
-                    <button
-                      type="button"
-                      class={cn(
-                        'text-sm text-muted-foreground px-2.5 py-1.75 text-left rounded-md transition-([background-color,color] duration-150 ease-out) hover:cursor-pointer',
-                        props.activePage() === page.key
-                          ? 'text-accent-foreground font-medium bg-accent'
-                          : 'hover:text-foreground hover:bg-accent/30',
-                      )}
-                      onClick={() => props.setActivePage(page.key)}
-                    >
-                      <span class="flex gap-2 min-w-0 w-full items-center justify-between">
-                        <span class="truncate">{page.label}</span>
-                        <Show when={page.badge}>
-                          {(badge) => (
-                            <span class="text-[0.6rem] leading-none font-semibold px-1.25 py-0.75 border rounded-sm bg-background/70 shrink-0 uppercase">
-                              {badge()}
-                            </span>
-                          )}
-                        </Show>
-                      </span>
-                    </button>
-                  )}
-                </For>
-              </div>
-            </section>
-          )}
-        </For>
+        <ListBox
+          ariaLabel="Documentation pages"
+          items={items()}
+          selectionMode="single"
+          value={props.activePage()}
+          onChange={(value) => {
+            if (typeof value === 'string' || typeof value === 'number') {
+              props.setActivePage(String(value))
+            }
+          }}
+          classes={{
+            content: 'gap-0',
+            label:
+              'text-[0.68rem] text-muted-foreground tracking-[0.14em] font-semibold mb-1.5 mt-3 px-2 uppercase',
+            item: 'text-sm text-muted-foreground px-2.5 py-1.75 min-h-0 rounded-md transition-([background-color,color] duration-150 ease-out) data-highlighted:(text-muted-foreground bg-transparent) data-selected:(text-accent-foreground font-medium bg-accent) hover:(text-foreground bg-accent/30)',
+            itemWrapper: 'min-w-0',
+            itemLabel: 'truncate',
+          }}
+        />
 
         <Show when={grouped().length === 0}>
           <p class="text-xs text-muted-foreground px-2 py-3">No results</p>
@@ -98,15 +111,18 @@ export const Sidebar = (props: SidebarProps) => {
           <div class="text-[0.68rem] text-muted-foreground tracking-[0.14em] font-semibold mb-1.5 mt-3 px-2 uppercase">
             Resources
           </div>
-          <a
+          <Button
+            as="a"
             href="/llms.txt"
             rel="alternate external"
             type="text/markdown"
-            class="text-sm text-muted-foreground px-2.5 py-1.75 rounded-md flex gap-2 transition-([background-color,color] duration-150 ease-out) items-center hover:(text-foreground bg-accent/30) focus-visible:(outline-none ring-2 ring-ring ring-offset-2 ring-offset-background)"
+            variant="ghost"
+            size="sm"
+            leading="i-lucide-file-text"
+            class="text-muted-foreground w-full justify-start hover:(text-foreground bg-accent/30)"
           >
-            <span class="i-lucide-file-text shrink-0 size-4" aria-hidden="true" />
             <span class="truncate">llms.txt</span>
-          </a>
+          </Button>
         </section>
       </nav>
     </div>

--- a/docs/pages/form/checkbox/indeterminate-custom-icons.tsx
+++ b/docs/pages/form/checkbox/indeterminate-custom-icons.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from '@src'
+import { Button, Checkbox } from '@src'
 import { createSignal } from 'solid-js'
 
 export function IndeterminateCustomIcons() {
@@ -15,27 +15,15 @@ export function IndeterminateCustomIcons() {
         indeterminateIcon="i-lucide:ellipsis"
       />
       <div class="flex flex-wrap gap-2">
-        <button
-          type="button"
-          class="text-sm px-3 py-1.5 b-(1 border) rounded-md hover:bg-muted"
-          onClick={() => setIndeterminate('indeterminate')}
-        >
+        <Button variant="outline" size="sm" onClick={() => setIndeterminate('indeterminate')}>
           Set indeterminate
-        </button>
-        <button
-          type="button"
-          class="text-sm px-3 py-1.5 b-(1 border) rounded-md hover:bg-muted"
-          onClick={() => setIndeterminate(true)}
-        >
+        </Button>
+        <Button variant="outline" size="sm" onClick={() => setIndeterminate(true)}>
           Set checked
-        </button>
-        <button
-          type="button"
-          class="text-sm px-3 py-1.5 b-(1 border) rounded-md hover:bg-muted"
-          onClick={() => setIndeterminate(false)}
-        >
+        </Button>
+        <Button variant="outline" size="sm" onClick={() => setIndeterminate(false)}>
           Set unchecked
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/docs/pages/form/input/input-with-icons.tsx
+++ b/docs/pages/form/input/input-with-icons.tsx
@@ -1,4 +1,4 @@
-import { Input } from '@src'
+import { Icon, Input } from '@src'
 
 export function InputWithIcons() {
   return (
@@ -16,7 +16,7 @@ export function InputWithIcons() {
       <Input
         leading={
           <div class="text-muted-foreground flex gap-1 items-center">
-            <div class="i-lucide-globe" />
+            <Icon name="i-lucide-globe" />
             https://
           </div>
         }

--- a/docs/pages/form/multi-select/create-new-tags.tsx
+++ b/docs/pages/form/multi-select/create-new-tags.tsx
@@ -1,4 +1,4 @@
-import { MultiSelect } from '@src'
+import { Button, MultiSelect } from '@src'
 import type { MultiSelectT } from '@src'
 import { createSignal } from 'solid-js'
 
@@ -26,13 +26,9 @@ export function CreateNewTags() {
         placeholder="Type to create tags..."
         emptyRender={(ctx) => (
           <div class="p-2 text-center">
-            <button
-              type="button"
-              class="text-sm text-primary cursor-pointer hover:underline"
-              onClick={() => ctx.create()}
-            >
+            <Button variant="link" size="sm" class="text-primary" onClick={() => ctx.create()}>
               Create &ldquo;{ctx.inputValue}&rdquo;
-            </button>
+            </Button>
           </div>
         )}
       />

--- a/docs/pages/form/textarea/header-footer.tsx
+++ b/docs/pages/form/textarea/header-footer.tsx
@@ -1,4 +1,4 @@
-import { Textarea } from '@src'
+import { Button, Icon, Textarea } from '@src'
 import { createSignal } from 'solid-js'
 
 export function HeaderFooter() {
@@ -11,7 +11,7 @@ export function HeaderFooter() {
         header={
           <>
             <span class="font-semibold">Info text</span>
-            <span class="i-lucide-info text-base ms-auto" />
+            <Icon name="i-lucide-info" class="text-base ms-auto" />
           </>
         }
         classes={{
@@ -28,12 +28,9 @@ export function HeaderFooter() {
         footer={
           <>
             <span>{composerValue().length}/280 characters</span>
-            <button
-              type="button"
-              class="text-xs text-primary-foreground ms-auto px-2 py-1 rounded-md bg-primary"
-            >
+            <Button size="xs" class="ms-auto">
               Send
-            </button>
+            </Button>
           </>
         }
         classes={{
@@ -46,7 +43,7 @@ export function HeaderFooter() {
         placeholder="console.log('Hello, world!');"
         header={
           <>
-            <span class="i-lucide-code text-base" />
+            <Icon name="i-lucide-code" class="text-base" />
             <span>script.js</span>
           </>
         }

--- a/docs/pages/general/avatar/single-avatar.tsx
+++ b/docs/pages/general/avatar/single-avatar.tsx
@@ -1,4 +1,4 @@
-import { Avatar } from '@src'
+import { Avatar, Button } from '@src'
 import { createSignal } from 'solid-js'
 
 export function SingleAvatar() {
@@ -23,15 +23,14 @@ export function SingleAvatar() {
         }}
       />
 
-      <button
-        type="button"
-        class="text-sm px-3 py-2 b-1 b-border border-border rounded-md bg-background hover:bg-muted"
+      <Button
+        variant="outline"
         onClick={() => {
           setSource((current) => (current === IMAGE_A ? IMAGE_B : IMAGE_A))
         }}
       >
         Swap Source
-      </button>
+      </Button>
     </div>
   )
 }

--- a/docs/pages/general/button/icon-buttons.tsx
+++ b/docs/pages/general/button/icon-buttons.tsx
@@ -21,11 +21,7 @@ export function IconButtons() {
           </Button>
         )}
       </For>
-      <Button
-        variant="outline"
-        leading={<div class="i-lucide:arrow-left" />}
-        trailing={<div class="i-lucide:arrow-right" />}
-      >
+      <Button variant="outline" leading="i-lucide:arrow-left" trailing="i-lucide:arrow-right">
         Leading + trailing
       </Button>
     </div>

--- a/docs/pages/general/collapsible/uncontrolled.tsx
+++ b/docs/pages/general/collapsible/uncontrolled.tsx
@@ -1,4 +1,4 @@
-import { Card, Collapsible, Icon, Switch } from '@src'
+import { Button, Card, Collapsible, Icon, Switch } from '@src'
 import { createSignal } from 'solid-js'
 
 export function Uncontrolled() {
@@ -18,9 +18,10 @@ export function Uncontrolled() {
           <Collapsible
             transition={transition()}
             renderTrigger={(context) => (
-              <button
+              <Button
                 {...context.triggerProps}
-                class="text-sm flex w-full cursor-pointer items-center justify-between"
+                variant="ghost"
+                class="text-sm w-full justify-between"
               >
                 <span>How do I reset my password?</span>
                 <Icon
@@ -28,7 +29,7 @@ export function Uncontrolled() {
                   aria-hidden="true"
                   class={`text-muted-foreground shrink-0 size-4 transition-transform ${context.isOpen ? 'rotate-180' : ''}`}
                 />
-              </button>
+              </Button>
             )}
           >
             <div class="text-sm text-muted-foreground pt-3">

--- a/docs/pages/navigation/command-palette/custom-empty-state.tsx
+++ b/docs/pages/navigation/command-palette/custom-empty-state.tsx
@@ -1,4 +1,4 @@
-import { Button, CommandPalette } from '@src'
+import { Button, CommandPalette, Icon } from '@src'
 import { createSignal } from 'solid-js'
 
 export function CustomEmptyState() {
@@ -12,7 +12,7 @@ export function CustomEmptyState() {
         groups={[]}
         emptyRender={() => (
           <span class="flex flex-col gap-2 items-center">
-            <span class="i-lucide-search-x text-muted-foreground size-6" aria-hidden="true" />
+            <Icon name="i-lucide-search-x" class="text-muted-foreground size-6" />
             <span class="text-foreground font-medium">No commands found</span>
             <span class="text-xs">Try a different keyword or clear the search.</span>
           </span>

--- a/docs/pages/navigation/command-palette/custom-item-render.tsx
+++ b/docs/pages/navigation/command-palette/custom-item-render.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, CommandPalette } from '@src'
+import { Badge, Button, CommandPalette, Icon } from '@src'
 import type { CommandPaletteT } from '@src'
 import { createSignal } from 'solid-js'
 
@@ -41,7 +41,7 @@ export function CustomItemRender() {
         groups={GROUPS}
         itemRender={(ctx) => (
           <div class="flex flex-1 gap-3 min-w-0 items-center">
-            <span class="i-lucide-folder-kanban text-muted-foreground shrink-0" />
+            <Icon name="i-lucide-folder-kanban text-muted-foreground shrink-0" />
             <span class="flex flex-1 flex-col min-w-0">
               <span class="text-sm font-medium truncate">{ctx.item.label}</span>
               <span class="text-xs text-muted-foreground truncate">

--- a/docs/pages/navigation/command-palette/description-position.tsx
+++ b/docs/pages/navigation/command-palette/description-position.tsx
@@ -1,4 +1,4 @@
-import { Badge, Button, CommandPalette } from '@src'
+import { Badge, Button, CommandPalette, Icon } from '@src'
 import type { CommandPaletteT } from '@src'
 import { createSignal } from 'solid-js'
 
@@ -11,14 +11,14 @@ const GROUPS: CommandPaletteT.Group[] = [
         value: 'inbox',
         label: 'Inbox',
         description: '24 unread messages across all teams',
-        leadingRender: () => <span class="i-lucide-inbox" />,
+        leadingRender: () => <Icon name="i-lucide-inbox" />,
         trailingRender: () => <Badge variant="default">24</Badge>,
       },
       {
         value: 'settings',
         label: 'Settings',
         description: 'Workspace preferences and billing',
-        leadingRender: () => <span class="i-lucide-settings" />,
+        leadingRender: () => <Icon name="i-lucide-settings" />,
       },
     ],
   },

--- a/docs/pages/navigation/command-palette/loading.tsx
+++ b/docs/pages/navigation/command-palette/loading.tsx
@@ -1,4 +1,4 @@
-import { Button, CommandPalette } from '@src'
+import { Button, CommandPalette, Icon } from '@src'
 import type { CommandPaletteT } from '@src'
 import { createSignal } from 'solid-js'
 
@@ -12,19 +12,19 @@ export function Loading() {
         {
           value: 'new-issue',
           label: 'New Issue',
-          leadingRender: () => <span class="i-lucide-circle-plus" />,
+          leadingRender: () => <Icon name="i-lucide-circle-plus" />,
           trailingRender: () => <span class="text-xs text-muted-foreground">⌘N</span>,
         },
         {
           value: 'open-inbox',
           label: 'Open Inbox',
-          leadingRender: () => <span class="i-lucide-inbox" />,
+          leadingRender: () => <Icon name="i-lucide-inbox" />,
           trailingRender: () => <span class="text-xs text-muted-foreground">GI</span>,
         },
         {
           value: 'sync-roadmap',
           label: 'Sync Roadmap',
-          leadingRender: () => <span class="i-lucide-refresh-cw" />,
+          leadingRender: () => <Icon name="i-lucide-refresh-cw" />,
           description: 'Pull the latest planning updates',
         },
       ],

--- a/docs/pages/navigation/command-palette/position.tsx
+++ b/docs/pages/navigation/command-palette/position.tsx
@@ -1,4 +1,4 @@
-import { Button, CommandPalette } from '@src'
+import { Button, CommandPalette, Icon } from '@src'
 import type { CommandPaletteT } from '@src'
 import { createSignal } from 'solid-js'
 
@@ -12,18 +12,18 @@ export function Position() {
         {
           value: 'new-file',
           label: 'New File',
-          leadingRender: () => <span class="i-lucide-file-plus" />,
+          leadingRender: () => <Icon name="i-lucide-file-plus" />,
           trailingRender: () => <span class="text-xs text-muted-foreground">⌘N</span>,
         },
         {
           value: 'new-folder',
           label: 'New Folder',
-          leadingRender: () => <span class="i-lucide-folder-plus" />,
+          leadingRender: () => <Icon name="i-lucide-folder-plus" />,
         },
         {
           value: 'settings',
           label: 'Settings',
-          leadingRender: () => <span class="i-lucide-settings" />,
+          leadingRender: () => <Icon name="i-lucide-settings" />,
         },
       ],
     },

--- a/docs/pages/navigation/command-palette/real-world-example.tsx
+++ b/docs/pages/navigation/command-palette/real-world-example.tsx
@@ -1,4 +1,4 @@
-import { Button, CommandPalette, Kbd, KbdGroup } from '@src'
+import { Button, CommandPalette, Icon, Kbd, KbdGroup } from '@src'
 import type { CommandPaletteT } from '@src'
 import { createMemo, createSignal, onCleanup, onMount } from 'solid-js'
 
@@ -50,7 +50,7 @@ export function RealWorldExample() {
           value: 'open-project-switcher',
           label: 'Open project switcher',
           description: 'Jump between projects, teams, and recent workspaces.',
-          leadingRender: () => <span class="i-lucide-search-check" />,
+          leadingRender: () => <Icon name="i-lucide-search-check" />,
           trailingRender: () => (
             <KbdGroup
               items={[modifierLabel(), 'Shift', 'P']}
@@ -68,7 +68,7 @@ export function RealWorldExample() {
           value: 'go-issues',
           label: 'Go to issues',
           description: 'Open the active team issue board.',
-          leadingRender: () => <span class="i-lucide-circle-dot" />,
+          leadingRender: () => <Icon name="i-lucide-circle-dot" />,
           trailingRender: () => (
             <KbdGroup items={[modifierLabel(), 'I']} size="sm" class="text-muted-foreground" />
           ),
@@ -88,7 +88,7 @@ export function RealWorldExample() {
           value: 'new-issue',
           label: 'Create issue',
           description: 'Capture a bug or task without leaving the current page.',
-          leadingRender: () => <span class="i-lucide-file-plus-2" />,
+          leadingRender: () => <Icon name="i-lucide-file-plus-2" />,
           trailingRender: () => (
             <KbdGroup items={[modifierLabel(), 'N']} size="sm" class="text-muted-foreground" />
           ),
@@ -102,7 +102,7 @@ export function RealWorldExample() {
           value: 'toggle-sidebar',
           label: 'Toggle sidebar',
           description: 'Collapse navigation to focus on the current editor.',
-          leadingRender: () => <span class="i-lucide-panel-left-close" />,
+          leadingRender: () => <Icon name="i-lucide-panel-left-close" />,
           trailingRender: () => (
             <KbdGroup items={[modifierLabel(), 'B']} size="sm" class="text-muted-foreground" />
           ),
@@ -116,7 +116,7 @@ export function RealWorldExample() {
           value: 'open-billing',
           label: 'Open billing',
           description: 'Restricted to workspace owners.',
-          leadingRender: () => <span class="i-lucide-credit-card" />,
+          leadingRender: () => <Icon name="i-lucide-credit-card" />,
           disabled: true,
           trailingRender: () => <span class="text-xs text-muted-foreground">Owner only</span>,
         },

--- a/docs/pages/navigation/command-palette/sub-navigation.tsx
+++ b/docs/pages/navigation/command-palette/sub-navigation.tsx
@@ -1,4 +1,4 @@
-import { Button, CommandPalette } from '@src'
+import { Button, CommandPalette, Icon } from '@src'
 import type { CommandPaletteT } from '@src'
 import { createMemo, createSignal } from 'solid-js'
 
@@ -11,19 +11,19 @@ export function SubNavigation() {
         {
           value: 'create',
           label: 'Create',
-          leadingRender: () => <span class="i-lucide-plus-circle" />,
+          leadingRender: () => <Icon name="i-lucide-plus-circle" />,
           description: 'Create new resources',
         },
         {
           value: 'share',
           label: 'Share',
-          leadingRender: () => <span class="i-lucide-share-2" />,
+          leadingRender: () => <Icon name="i-lucide-share-2" />,
           description: 'Share with others',
         },
         {
           value: 'delete',
           label: 'Delete',
-          leadingRender: () => <span class="i-lucide-trash-2" />,
+          leadingRender: () => <Icon name="i-lucide-trash-2" />,
         },
       ],
     },
@@ -36,17 +36,17 @@ export function SubNavigation() {
         {
           value: 'create-new-file',
           label: 'New File',
-          leadingRender: () => <span class="i-lucide-file-plus" />,
+          leadingRender: () => <Icon name="i-lucide-file-plus" />,
         },
         {
           value: 'create-new-folder',
           label: 'New Folder',
-          leadingRender: () => <span class="i-lucide-folder-plus" />,
+          leadingRender: () => <Icon name="i-lucide-folder-plus" />,
         },
         {
           value: 'create-new-project',
           label: 'New Project',
-          leadingRender: () => <span class="i-lucide-git-branch" />,
+          leadingRender: () => <Icon name="i-lucide-git-branch" />,
         },
       ],
     },
@@ -59,13 +59,13 @@ export function SubNavigation() {
         {
           value: 'share-copy-link',
           label: 'Copy Link',
-          leadingRender: () => <span class="i-lucide-link" />,
+          leadingRender: () => <Icon name="i-lucide-link" />,
           trailingRender: () => <span class="text-xs text-muted-foreground">⌘L</span>,
         },
         {
           value: 'share-send-email',
           label: 'Send via Email',
-          leadingRender: () => <span class="i-lucide-mail" />,
+          leadingRender: () => <Icon name="i-lucide-mail" />,
         },
       ],
     },

--- a/docs/pages/navigation/command-palette/usage.tsx
+++ b/docs/pages/navigation/command-palette/usage.tsx
@@ -1,4 +1,4 @@
-import { Button, CommandPalette, Kbd, KbdGroup } from '@src'
+import { Button, CommandPalette, Icon, Kbd, KbdGroup } from '@src'
 import type { CommandPaletteT } from '@src'
 import { createSignal, onCleanup, onMount } from 'solid-js'
 
@@ -10,19 +10,19 @@ const GROUPS: CommandPaletteT.Group[] = [
       {
         value: 'new-issue',
         label: 'New Issue',
-        leadingRender: () => <span class="i-lucide-circle-plus" />,
+        leadingRender: () => <Icon name="i-lucide-circle-plus" />,
         trailingRender: () => <span class="text-xs text-muted-foreground">⌘N</span>,
       },
       {
         value: 'open-inbox',
         label: 'Open Inbox',
-        leadingRender: () => <span class="i-lucide-inbox" />,
+        leadingRender: () => <Icon name="i-lucide-inbox" />,
         trailingRender: () => <span class="text-xs text-muted-foreground">GI</span>,
       },
       {
         value: 'sync-roadmap',
         label: 'Sync Roadmap',
-        leadingRender: () => <span class="i-lucide-refresh-cw" />,
+        leadingRender: () => <Icon name="i-lucide-refresh-cw" />,
         description: 'Pull the latest planning updates',
       },
     ],
@@ -34,23 +34,23 @@ const GROUPS: CommandPaletteT.Group[] = [
       {
         value: 'go-dashboard',
         label: 'Dashboard',
-        leadingRender: () => <span class="i-lucide-layout-dashboard" />,
+        leadingRender: () => <Icon name="i-lucide-layout-dashboard" />,
       },
       {
         value: 'go-projects',
         label: 'Projects',
-        leadingRender: () => <span class="i-lucide-folder-kanban" />,
+        leadingRender: () => <Icon name="i-lucide-folder-kanban" />,
       },
       {
         value: 'go-settings',
         label: 'Settings',
-        leadingRender: () => <span class="i-lucide-settings" />,
+        leadingRender: () => <Icon name="i-lucide-settings" />,
         description: 'Preferences',
       },
       {
         value: 'go-billing',
         label: 'Billing',
-        leadingRender: () => <span class="i-lucide-credit-card" />,
+        leadingRender: () => <Icon name="i-lucide-credit-card" />,
         disabled: true,
       },
     ],

--- a/docs/pages/navigation/command-palette/with-close-button.tsx
+++ b/docs/pages/navigation/command-palette/with-close-button.tsx
@@ -1,4 +1,4 @@
-import { Button, CommandPalette } from '@src'
+import { Button, CommandPalette, Icon } from '@src'
 import type { CommandPaletteT } from '@src'
 import { createSignal } from 'solid-js'
 
@@ -12,19 +12,19 @@ export function WithCloseButton() {
         {
           value: 'new-issue',
           label: 'New Issue',
-          leadingRender: () => <span class="i-lucide-circle-plus" />,
+          leadingRender: () => <Icon name="i-lucide-circle-plus" />,
           trailingRender: () => <span class="text-xs text-muted-foreground">⌘N</span>,
         },
         {
           value: 'open-inbox',
           label: 'Open Inbox',
-          leadingRender: () => <span class="i-lucide-inbox" />,
+          leadingRender: () => <Icon name="i-lucide-inbox" />,
           trailingRender: () => <span class="text-xs text-muted-foreground">GI</span>,
         },
         {
           value: 'sync-roadmap',
           label: 'Sync Roadmap',
-          leadingRender: () => <span class="i-lucide-refresh-cw" />,
+          leadingRender: () => <Icon name="i-lucide-refresh-cw" />,
           description: 'Pull the latest planning updates',
         },
       ],
@@ -36,23 +36,23 @@ export function WithCloseButton() {
         {
           value: 'go-dashboard',
           label: 'Dashboard',
-          leadingRender: () => <span class="i-lucide-layout-dashboard" />,
+          leadingRender: () => <Icon name="i-lucide-layout-dashboard" />,
         },
         {
           value: 'go-projects',
           label: 'Projects',
-          leadingRender: () => <span class="i-lucide-folder-kanban" />,
+          leadingRender: () => <Icon name="i-lucide-folder-kanban" />,
         },
         {
           value: 'go-settings',
           label: 'Settings',
-          leadingRender: () => <span class="i-lucide-settings" />,
+          leadingRender: () => <Icon name="i-lucide-settings" />,
           description: 'Preferences',
         },
         {
           value: 'go-billing',
           label: 'Billing',
-          leadingRender: () => <span class="i-lucide-credit-card" />,
+          leadingRender: () => <Icon name="i-lucide-credit-card" />,
           disabled: true,
         },
       ],

--- a/docs/pages/navigation/sidebar-frame/basic.tsx
+++ b/docs/pages/navigation/sidebar-frame/basic.tsx
@@ -1,5 +1,4 @@
-import { Button, Icon, SidebarFrame } from '@src'
-import { For } from 'solid-js'
+import { Button, Icon, ListBox, SidebarFrame } from '@src'
 
 const PAGES = [
   'Introduction',
@@ -22,18 +21,13 @@ export function Basic() {
         sidebarHeaderRender={() => <div class="text-sm font-semibold p-4">Documentation</div>}
         sidebarBodyRender={() => (
           <div class="p-2 h-full overflow-y-auto">
-            <div class="flex flex-col gap-1">
-              <For each={PAGES}>
-                {(item) => (
-                  <button
-                    type="button"
-                    class="text-sm px-2.5 py-1.5 text-left rounded-md hover:bg-accent"
-                  >
-                    {item}
-                  </button>
-                )}
-              </For>
-            </div>
+            <ListBox
+              items={PAGES.map((item) => ({ value: item, label: item }))}
+              classes={{
+                content: 'gap-1',
+                item: 'text-sm px-2.5 py-1.5 min-h-0 rounded-md hover:bg-accent data-highlighted:bg-transparent',
+              }}
+            />
           </div>
         )}
         mainRender={(ctx) => (

--- a/docs/pages/navigation/sidebar-frame/header-footer-slots.tsx
+++ b/docs/pages/navigation/sidebar-frame/header-footer-slots.tsx
@@ -1,5 +1,4 @@
-import { Button, SidebarFrame } from '@src'
-import { For } from 'solid-js'
+import { Button, ListBox, SidebarFrame } from '@src'
 
 const TASKS = [
   'Release checklist',
@@ -29,18 +28,13 @@ export function HeaderFooterSlots() {
         )}
         sidebarBodyRender={() => (
           <div class="p-2">
-            <div class="flex flex-col gap-1">
-              <For each={TASKS}>
-                {(task) => (
-                  <button
-                    type="button"
-                    class="text-sm px-2.5 py-1.5 text-left rounded-md hover:bg-accent"
-                  >
-                    {task}
-                  </button>
-                )}
-              </For>
-            </div>
+            <ListBox
+              items={TASKS.map((item) => ({ value: item, label: item }))}
+              classes={{
+                content: 'gap-1',
+                item: 'text-sm px-2.5 py-1.5 min-h-0 rounded-md hover:bg-accent data-highlighted:bg-transparent',
+              }}
+            />
           </div>
         )}
         sidebarFooterRender={() => (

--- a/docs/pages/navigation/sidebar-frame/sheet-resizable-render.tsx
+++ b/docs/pages/navigation/sidebar-frame/sheet-resizable-render.tsx
@@ -1,5 +1,5 @@
-import { Button, SidebarFrame, SidebarFrameSheetResizableRender } from '@src'
-import { For, createSignal } from 'solid-js'
+import { Button, ListBox, SidebarFrame, SidebarFrameSheetResizableRender } from '@src'
+import { createSignal } from 'solid-js'
 
 const ITEMS = ['Overview', 'Members', 'Billing', 'Security', 'Audit Log', 'API Keys']
 
@@ -32,18 +32,13 @@ export function SheetResizableRender() {
         sidebarHeaderRender={() => <div class="text-sm p-3">Workspace</div>}
         sidebarBodyRender={() => (
           <div class="p-2 h-full overflow-y-auto">
-            <div class="flex flex-col gap-1">
-              <For each={ITEMS}>
-                {(item) => (
-                  <button
-                    type="button"
-                    class="text-sm px-2.5 py-1.5 text-left rounded-md hover:bg-accent"
-                  >
-                    {item}
-                  </button>
-                )}
-              </For>
-            </div>
+            <ListBox
+              items={ITEMS.map((item) => ({ value: item, label: item }))}
+              classes={{
+                content: 'gap-1',
+                item: 'text-sm px-2.5 py-1.5 min-h-0 rounded-md hover:bg-accent data-highlighted:bg-transparent',
+              }}
+            />
           </div>
         )}
         mainRender={() => (

--- a/docs/pages/overlay/context-menu/sizes.tsx
+++ b/docs/pages/overlay/context-menu/sizes.tsx
@@ -1,4 +1,4 @@
-import { ContextMenu } from '@src'
+import { Button, ContextMenu } from '@src'
 import type { ContextMenuT } from '@src'
 import { For } from 'solid-js'
 
@@ -31,12 +31,7 @@ export function Sizes() {
       <For each={SIZES}>
         {(size) => (
           <ContextMenu size={size} items={ITEMS}>
-            <button
-              type="button"
-              class="text-sm px-3 py-2 b-1 b-border border-border rounded-md bg-background"
-            >
-              Right click ({size})
-            </button>
+            <Button variant="outline">Right click ({size})</Button>
           </ContextMenu>
         )}
       </For>

--- a/docs/pages/overlay/toast/toast.mdx
+++ b/docs/pages/overlay/toast/toast.mdx
@@ -23,12 +23,13 @@ Then import styles, mount a `Toaster` instance.
 ```tsx
 import 'solid-toaster/style.css'
 
+import { Button } from '@subframe7536/moraine'
 import { Toaster, toast } from 'solid-toaster'
 
 export default function App() {
   return (
     <>
-      <button onClick={() => toast.success('Saved!')}>Toast</button>
+      <Button onClick={() => toast.success('Saved!')}>Toast</Button>
       <Toaster />
     </>
   )

--- a/docs/pages/overlay/tooltip/keyboard-shortcuts.tsx
+++ b/docs/pages/overlay/tooltip/keyboard-shortcuts.tsx
@@ -4,17 +4,17 @@ export function KeyboardShortcuts() {
   return (
     <div class="flex flex-wrap gap-4 items-center">
       <Tooltip text="Save" kbds={['Ctrl', 'S']} open>
-        <Button variant="outline" leading={<div class="i-lucide-save" />}>
+        <Button variant="outline" leading="i-lucide-save">
           Save
         </Button>
       </Tooltip>
       <Tooltip text="Undo" kbds={['Ctrl', 'Z']}>
-        <Button variant="outline" leading={<div class="i-lucide-undo" />}>
+        <Button variant="outline" leading="i-lucide-undo">
           Undo
         </Button>
       </Tooltip>
       <Tooltip text="Search" kbds={['Ctrl', 'K']}>
-        <Button variant="outline" leading={<div class="i-lucide-search" />}>
+        <Button variant="outline" leading="i-lucide-search">
           Search
         </Button>
       </Tooltip>

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "cls-variant": "^1.2.0"
   },
   "devDependencies": {
-    "@expressive-code/plugin-line-numbers": "^0.44.0",
+    "@expressive-code/plugin-line-numbers": "^0.42.0",
     "@iconify-json/lucide": "^1.2.117",
     "@iconify/tailwind": "1.2.0",
     "@rolldown/pluginutils": "*",

--- a/src/elements/list-box/list-box.test.tsx
+++ b/src/elements/list-box/list-box.test.tsx
@@ -56,6 +56,16 @@ describe('ListBox', () => {
     )
   })
 
+  test('keeps DOM focus on the listbox after pointer selection', async () => {
+    const screen = render(() => <ListBox selectionMode="single" items={ITEMS} />)
+    const listbox = screen.getByRole('listbox')
+
+    await fireEvent.click(screen.getByRole('option', { name: 'Banana' }))
+
+    expect(document.activeElement).toBe(listbox)
+    expect(listbox.getAttribute('aria-activedescendant')).toBe(`${listbox.id}-apple`)
+  })
+
   test('supports multiple selection and skips disabled items', async () => {
     const onChange = vi.fn()
     const screen = render(() => (

--- a/src/elements/list-box/list-box.tsx
+++ b/src/elements/list-box/list-box.tsx
@@ -249,6 +249,7 @@ export function ListBox<TItem extends ListBoxT.Item = ListBoxT.Item>(
     defaultValue: () => merged.defaultValue ?? (merged.selectionMode === 'multiple' ? [] : null),
   })
   const [highlightedValue, setHighlightedValue] = createSignal<ListBoxT.Value | undefined>()
+  let contentRef: HTMLUListElement | undefined
   const items = createMemo(() => merged.items ?? [])
   const visibleEntries = createMemo(() =>
     items().filter((entry) => {
@@ -371,6 +372,12 @@ export function ListBox<TItem extends ListBoxT.Item = ListBoxT.Item>(
     onNavigationKeyDown(event, highlightedValue(), 'vertical')
   }
 
+  function focusContent(): void {
+    if (isInteractive() && document.activeElement !== contentRef) {
+      contentRef?.focus({ preventScroll: true })
+    }
+  }
+
   function ListBoxOption(optionProps: OptionProps): JSX.Element {
     const context = createItemContext(
       () => optionProps.item,
@@ -409,6 +416,7 @@ export function ListBox<TItem extends ListBoxT.Item = ListBoxT.Item>(
           }
         }}
         onClick={(event) => {
+          focusContent()
           const { defaultPrevented } = callHandler(event, itemAttributes()?.onClick)
           if (!defaultPrevented) {
             selectItem(optionProps.item, optionProps.index())
@@ -508,6 +516,9 @@ export function ListBox<TItem extends ListBoxT.Item = ListBoxT.Item>(
 
   return (
     <ul
+      ref={(element) => {
+        contentRef = element
+      }}
       id={listBoxId()}
       role={isInteractive() ? 'listbox' : undefined}
       aria-label={merged.ariaLabel}


### PR DESCRIPTION
### Motivation
- Standardize docs UI by replacing ad-hoc markup with core components (`Button`, `Icon`, `ListBox`) to ensure consistent behavior and styling across examples and pages.
- Expose the original markdown source in compiled pages so authors and consumers can view and copy the raw content from the docs UI.
- Tweak tab/indicator and code block styles to better position copy controls and indicators.
- Keep lockfile and `package.json` aligned to a compatible `@expressive-code` release to avoid runtime/resolution mismatches.

### Description
- Pass `markdownSource` from `compileMarkdownPage` into the generated `Markdown` page and add a `Copy as Markdown` action implemented in `docs/components/markdown.tsx` that uses the Clipboard API and shows temporary success/failure state.
- Replace many raw `button`/`a`/inline icon spans with `Button` and `Icon` components across documentation pages and components, and swap list rendering in the sidebar and several examples to use `ListBox` with a memoized `items` list.
- Adjust several CSS class constants (`docs-code-block.class.ts`, `mdx-components.class.ts`) to fine-tune copy button placement and tab indicator appearance.
- Downgrade/pin `@expressive-code/core` and `@expressive-code/plugin-line-numbers` references in `bun.lock` and `package.json` to `0.42.0` for consistency with other plugin versions.
- Update unit tests to cover the new markdown copy behavior, adjusted indicator expectations, and ListBox-based sidebar interactions.

### Testing
- Ran unit tests with `vitest --run` and verified updated test suites including `markdown.test.tsx`, `mdx-components.test.tsx`, and `sidebar.test.tsx` were executed and passed.
- Exercised the new copy flow in `Markdown` tests by stubbing `navigator.clipboard.writeText` and asserting the clipboard call and success message were shown.
- Confirmed the tab indicator class update is validated by the modified `mdx-components` test.
- Verified the sidebar selection test was adapted to the `ListBox` rendering and passed under the test runner.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5735de5d5c8330b18e7079dcc134bf)