### PR TITLE
Use MDAST plugin to collect MDX components for llms.txt generation

### DIFF
--- a/docs/build/llms.ts
+++ b/docs/build/llms.ts
@@ -3,7 +3,13 @@ import { readFile } from 'node:fs/promises'
 import type { ServerResponse } from 'node:http'
 import path from 'node:path'
 
-import { defineMdastPlugin, mdxToJs } from 'satteri'
+import {
+  createMdxMdastHandle,
+  defineMdastPlugin,
+  dropHandle,
+  resolveMdastSubscriptions,
+  visitMdastHandle,
+} from 'satteri'
 import type { Plugin } from 'vite'
 
 import { loadComponentApiDoc, loadApiDocIndex } from './api-doc/load'
@@ -356,14 +362,7 @@ function renderComponentNode(
   throw new Error(`[docs-llms] unsupported JSX component <${node.name}> in ${context.sourcePath}`)
 }
 
-function collectMdxComponents(
-  source: string,
-  sourcePath: string,
-): {
-  plugin: ReturnType<typeof defineMdastPlugin>
-  nodes: MdxComponentNode[]
-} {
-  const nodes: MdxComponentNode[] = []
+function createLlmsMdastPlugin(source: string, sourcePath: string, nodes: MdxComponentNode[]) {
   const sourceBuffer = Buffer.from(source)
   const visit = (node: unknown) => {
     const record = asObjectRecord(node)
@@ -389,28 +388,40 @@ function collectMdxComponents(
     })
   }
 
-  return {
-    plugin: defineMdastPlugin({
-      name: `moraine-llms-components-${path.basename(sourcePath)}`,
-      mdxJsxFlowElement: visit,
-      mdxJsxTextElement: visit,
-    }),
-    nodes,
+  return defineMdastPlugin({
+    name: `moraine-llms-components-${path.basename(sourcePath)}`,
+    mdxJsxFlowElement: visit,
+    mdxJsxTextElement: visit,
+  })
+}
+
+async function collectMdxComponents(source: string, sourcePath: string) {
+  const nodes: MdxComponentNode[] = []
+  const plugin = createLlmsMdastPlugin(source, sourcePath, nodes)
+  const handle = createMdxMdastHandle(source, DOCS_MDX_FEATURES)
+  try {
+    await visitMdastHandle(
+      handle,
+      plugin,
+      resolveMdastSubscriptions(plugin),
+      source,
+      undefined,
+      {},
+      'mdx',
+    )
+  } finally {
+    dropHandle(handle)
   }
+  return nodes
 }
 
 async function convertPageMarkdown(
   source: string,
   context: PageConversionContext,
 ): Promise<string> {
-  const components = collectMdxComponents(source, context.sourcePath)
-  await mdxToJs(source, {
-    jsx: true,
-    features: DOCS_MDX_FEATURES,
-    mdastPlugins: [components.plugin],
-  })
+  const components = await collectMdxComponents(source, context.sourcePath)
   const replacements = await Promise.all(
-    components.nodes.map(async (node) => ({
+    components.map(async (node) => ({
       start: node.start,
       end: node.end,
       value: await renderComponentNode(node, context),


### PR DESCRIPTION
### Motivation

- Replace the heavy `mdxToJs` compilation previously used to discover MDX JSX components with a focused MDAST visitor to reduce compile work and improve docs build performance.
- Ensure parser resources are explicitly released after each page conversion to avoid leaking handles or memory.
- Preserve existing component replacement and validation semantics while improving maintainability and performance.

### Description

- Added an MDAST plugin factory `createLlmsMdastPlugin` and a `collectMdxComponents` flow which uses `createMdxMdastHandle`, `visitMdastHandle`, `resolveMdastSubscriptions`, and `dropHandle` from `satteri` to collect MDX component nodes without running `mdxToJs`.
- Replaced the prior `collectMdxComponents`/`mdxToJs` approach in `convertPageMarkdown` with the new `collectMdxComponents` that returns a list of component nodes and keeps the existing async `renderComponentNode` replacement logic.
- Explicitly drops the MDAST handle after visiting to guarantee resource cleanup and avoid retaining parser state between conversions.
- Kept all rendering, internal link normalization, API reference rendering, and frontmatter behavior unchanged.

### Testing

- Ran `bun run test docs/build/llms.test.ts` and the test file passed (3 tests).
- Ran repository QA (`bun run qa`) which ran formatting, lint, and `tsc --noEmit` and completed without errors.
- Ran the full test suite with `bun run test` and it completed successfully.
- Microbenchmarks for `buildLlmsDocuments` on the repo (47 documents) showed improvement from ~1149.56 ms cold / ~409.87 ms warm to ~841.58 ms cold / ~296 ms median warm, so the refactor was retained.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69c9935b1083308e97aba3771d3644)